### PR TITLE
[WC-815]

### DIFF
--- a/src/pages/Courses/form.tsx
+++ b/src/pages/Courses/form.tsx
@@ -58,10 +58,18 @@ export default () => {
     showModal: false,
     courseId: 0,
   });
+  const [isFirstTimeEdit, setIsFirstTimeEdit] = useState(true);
 
   const locales: string[] = getAllLocales() || [];
 
   const { setInitialState, initialState } = useModel('@@initialState');
+
+  useEffect(() => {
+    if (tab === 'attributes' && data && isFirstTimeEdit) {
+      validateCourseEdit(data);
+      setIsFirstTimeEdit(false);
+    }
+  }, [data, tab, isFirstTimeEdit]);
 
   useEffect(() => {
     if (course === 'new') {
@@ -75,10 +83,6 @@ export default () => {
       const response = await getCourse(Number(course));
 
       if (response.success) {
-        if (tab === 'attributes') {
-          validateCourseEdit(response.data);
-        }
-
         setData({
           ...response.data,
           categories: response.data.categories?.map(categoriesArrToIds),
@@ -107,8 +111,8 @@ export default () => {
 
         const postData = {
           ...values,
-          active_from: values.active_from || null,
-          active_to: values.active_to || null,
+          active_from: values.active_from || data?.active_from || null,
+          active_to: values.active_to || data?.active_to || null,
           authors:
             values.authors &&
             values.authors.map((author) => (typeof author === 'object' ? author.id : author)),
@@ -135,8 +139,6 @@ export default () => {
           response = await updateCourse(Number(course), postData);
           if (response.success) {
             setUnsavedChanges(false);
-            validateCourseEdit(response.data);
-            history.push(`/courses/list/${response.data.id}/attributes`);
           }
         }
         message.success(response.message);


### PR DESCRIPTION
[WC-815]
Fix bug with changing tab to first after saving changes in other tabs.
Fix bug with clearing active_from and active_to parameters when we saving data from other tabs than attributes.
Show information about editing sensitive data only one time when we open page with course.

https://escl24.atlassian.net/browse/WC-815

[WC-815]: https://escl24.atlassian.net/browse/WC-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ