### PR TITLE
[WC-857] - Add hideLabel prop to SecureUpload component

### DIFF
--- a/src/components/H5P/upload.tsx
+++ b/src/components/H5P/upload.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 export const UploadH5P: React.FC<{
   onSuccess: (response: any) => void;
   onError: () => void;
-}> = ({ onSuccess, onError }) => {
+  hideLabel?: boolean;
+}> = ({ onSuccess, onError, hideLabel }) => {
   return (
     <SecureUpload
       url="/api/admin/hh5p/content/upload"
       name="h5p_file"
       accept=".h5p"
+      hideLabel={hideLabel}
       onChange={(info) => {
         if (info.file.status === 'done') {
           if (info.file.response) {

--- a/src/components/Scorm/upload.tsx
+++ b/src/components/Scorm/upload.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 export const UploadScorm: React.FC<{
   onSuccess: (scorm: API.SCORM) => void;
   onError: (error: API.DefaultResponseError) => void;
-}> = ({ onSuccess, onError }) => {
+  hideLabel?: boolean;
+}> = ({ onSuccess, onError, hideLabel }) => {
   return (
     <SecureUpload
       url="/api/admin/scorm/upload"
       name="zip"
       accept="application/zip"
+      hideLabel={hideLabel}
       onChange={(info) => {
         if (info.file.response) {
           // @ts-ignore

--- a/src/components/SecureUpload/index.tsx
+++ b/src/components/SecureUpload/index.tsx
@@ -22,6 +22,7 @@ export type SecureUploadType<T = API.File> = {
   formProps?: FormProps;
   maxFiles?: number;
   clearListAfterUpload?: boolean;
+  hideLabel?: boolean;
 };
 
 function SecureUpload<Type = API.File>({
@@ -37,6 +38,7 @@ function SecureUpload<Type = API.File>({
   formProps,
   maxFiles,
   clearListAfterUpload,
+  hideLabel,
 }: PropsWithChildren<SecureUploadType<Type>>) {
   const [infoState, setInfoState] = useState<UploadChangeParam<UploadFile<any>>>();
   const intl = useIntl();
@@ -77,7 +79,7 @@ function SecureUpload<Type = API.File>({
           }
         }}
         // name={name}
-        label={<FormattedMessage id="upload" />}
+        label={!hideLabel && <FormattedMessage id="upload" />}
         max={maxFiles ?? 2}
         fieldProps={{
           data,

--- a/src/pages/H5P/index.tsx
+++ b/src/pages/H5P/index.tsx
@@ -76,10 +76,9 @@ const TableList: React.FC = () => {
     {
       title: <FormattedMessage id="ID" defaultMessage="ID" />,
       dataIndex: 'id',
-      sorter: false,
+      sorter: true,
       search: false,
     },
-
     {
       title: <FormattedMessage id="newH5P" defaultMessage="newH5P" />,
       dataIndex: 'upload',
@@ -89,6 +88,7 @@ const TableList: React.FC = () => {
       renderFormItem: () => [
         <UploadH5P
           key={'upload'}
+          hideLabel
           onSuccess={() => {
             if (actionRef.current) {
               actionRef.current.reload();

--- a/src/pages/Scorm/index.tsx
+++ b/src/pages/Scorm/index.tsx
@@ -23,11 +23,13 @@ const TableList: React.FC = () => {
       title: <FormattedMessage id="ID" defaultMessage="ID" />,
       dataIndex: 'id',
       hideInSearch: true,
+      sorter: true,
     },
     {
       title: <FormattedMessage id="version" defaultMessage="version" />,
       dataIndex: 'version',
       hideInSearch: true,
+      sorter: true,
     },
 
     {
@@ -39,6 +41,7 @@ const TableList: React.FC = () => {
       renderFormItem: () => [
         <UploadScorm
           key="upload"
+          hideLabel
           onSuccess={() => {
             if (actionRef.current) {
               actionRef.current.reload();


### PR DESCRIPTION
[WC-857]
Add hideLabel prop to SecureUpload component.
Hide label from SecureUpload in SCORM and H5p tables.

https://escl24.atlassian.net/browse/WC-857

[WC-857]: https://escl24.atlassian.net/browse/WC-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ