### PR TITLE
[WC-872] - Add translations for field types in ModelField modal form

### DIFF
--- a/src/components/ModelFields/ModalForm.tsx
+++ b/src/components/ModelFields/ModalForm.tsx
@@ -90,7 +90,7 @@ export const ModelFieldsModalForm: React.FC<{
         tooltip={<FormattedMessage id="type_tooltip" defaultMessage="type_tooltip" />}
         options={(Object.keys(ModelFieldType) as (keyof typeof ModelFieldType)[]).map((key) => ({
           label: intl.formatMessage({
-            id: ModelFieldType[key],
+            id: `model.${ModelFieldType[key]}`,
           }),
           value: ModelFieldType[key],
         }))}
@@ -123,7 +123,7 @@ export const ModelFieldsModalForm: React.FC<{
             </a>
           </span>
         }
-        tooltip={<FormattedMessage id="available-validation-rules" />}
+        tooltip={<FormattedMessage id="available-validation-rules-tooltip" />}
         valuePropName="value"
       >
         <JsonEditor />
@@ -171,7 +171,7 @@ export const ModelFieldsModalForm: React.FC<{
       <ProForm.Item
         name="extra"
         label={<FormattedMessage id="extra" />}
-        tooltip={<FormattedMessage id="extra" />}
+        tooltip={<FormattedMessage id="extra_tooltip" />}
         valuePropName="value"
       >
         <JsonEditor />

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -463,14 +463,19 @@ export default {
   rules: 'Rules',
   visibility: 'Visibility',
   name_tooltip: 'Name',
-  type_tooltip: 'type of field',
+  type_tooltip:
+    'Specify the field type: single choose field, numeric field, varchar field, text field or JSON format',
   rules_tooltip: 'a json list of string rules used on create/update model',
-  extra_tooltip: 'a json extra description',
-  default_tooltip: 'default value, if model has no value this will be served',
-  purchasable_tooltip: 'Can user buy this product or is available only by manual assignment',
+  extra: 'Additional values',
+  extra_tooltip:
+    'Additional JSON values. For example if you want to create field translations, you need to enter values in the editor: [{"pl": "Polskie tłumaczenie"},{"en": "English translation"}]',
+  default_tooltip:
+    'The default value for the selected field, which will be displayed if the value has not yet been saved in the database',
   visibility_tooltip:
-    'visibility of field. Must be power of 2. Use  1 to Public access, 2 for Authorized, 4 for Admin, and rest is up to you',
-  'available-validation-rules': 'available validation rules',
+    'Field visibility for API. Value 1 - publicly visible, 2 - visible to logged in users, 4 - visible to the administrator.',
+  'available-validation-rules': 'available validation methods',
+  'available-validation-rules-tooltip':
+    'Validation of the selected field. For example if you want a field to be required, you must provide a value in the JSON editor: ["required"]',
   Products: 'Products',
   free: 'free',
   free_capi: 'Free',
@@ -616,4 +621,9 @@ export default {
   'Course imported successfully': 'Course imported successfully',
   'Course updated successfully': 'Course updated successfully',
   'Export created': 'File exported successfully',
+  'model.boolean': 'Single choose field',
+  'model.number': 'Numeric field',
+  'model.varchar': 'Text field (varchar)',
+  'model.text': 'Text field',
+  'model.json': 'JSON',
 };

--- a/src/locales/fr-FR.ts
+++ b/src/locales/fr-FR.ts
@@ -436,16 +436,20 @@ export default {
   rules: 'Règles',
   visibility: 'Visibilité',
   name_tooltip: 'Nom',
-  type_tooltip: 'type de champ',
+  type_tooltip:
+    'Spécifiez le type de champ : champ à choix unique, champ numérique, champ varchar, champ de texte ou format JSON',
   rules_tooltip:
-    'une liste de règles de chaînes JSON utilisées lors de la création/mise à jour du modèle',
-  extra_tooltip: 'une description supplémentaire en JSON',
-  default_tooltip: "valeur par défaut, si le modèle n'a pas de valeur, celle-ci sera utilisée",
+    'une liste json de règles de chaîne utilisées sur le modèle de création/mise à jour',
+  extra: 'Valeurs supplémentaires',
+  extra_tooltip: `Valeurs JSON supplémentaires. Par exemple, si vous souhaitez créer des traductions de champs, vous devez saisir des valeurs dans l'éditeur: [{"pl": "Polskie tłumaczenie"},{"en": "English translation"}]`,
+  default_tooltip:
+    "La valeur par défaut du champ sélectionné, qui sera affichée si la valeur n'a pas encore été enregistrée dans la base de données",
+  visibility_tooltip:
+    "Visibilité des champs pour l'API. Valeur 1 - visible publiquement, 2 - visible pour les utilisateurs connectés, 4 - visible pour l'administrateur.",
+  'available-validation-rules': 'méthodes de validation disponibles',
+  'available-validation-rules-tooltip': `Validation du champ sélectionné. Par exemple, si vous souhaitez qu'un champ soit obligatoire, vous devez fournir une valeur dans l'éditeur JSON: ["required"]`,
   purchasable_tooltip:
     "L'utilisateur peut-il acheter ce produit ou est-il disponible uniquement par attribution manuelle ?",
-  visibility_tooltip:
-    "visibilité du champ. Doit être une puissance de 2. Utilisez 1 pour l'accès public, 2 pour les utilisateurs autorisés, 4 pour les administrateurs et le reste est à votre discrétion.",
-  'available-validation-rules': 'règles de validation disponibles',
   Products: 'Produits',
   free: 'gratuit',
   free_capi: 'Gratuit',
@@ -556,4 +560,9 @@ export default {
   'Course imported successfully': 'Cours importé avec succès',
   'Course updated successfully': 'Cours mis à jour avec succès',
   'Export created': 'Fichier exporté avec succès',
+  'model.boolean': 'Champ à choix unique',
+  'model.number': 'Champ numérique',
+  'model.varchar': 'Champ de texte (varchar)',
+  'model.text': 'Champ de texte',
+  'model.json': 'JSON',
 };

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -451,13 +451,19 @@ export default {
   rules: 'Zasady walidacji',
   visibility: 'Widoczność pola',
   name_tooltip: 'Nazwa',
-  type_tooltip: 'typ',
+  type_tooltip:
+    'Określ typ pola: pole jednokrotnego wyboru, pole numeryczne, pole varchar, pole tekstowe lub format JSON',
   rules_tooltip: 'a json list of string rules used on create/update model',
-  extra_tooltip: 'a json extra description',
-  default_tooltip: 'jezeli model nie ma zapisanej wartość pojawi się wartość domyślna ',
+  extra: 'Wartości dodatkowe',
+  extra_tooltip:
+    'Dodatkowe wartości w formacie JSON. Przykładowo, jeśli chcemy stworzyć tłumaczenia pól, musimy w edytorze wprowadzić wartości: [{"pl": "Polskie tłumaczenie"},{"en": "English translation"}]',
+  default_tooltip:
+    'Wartość domyślna dla wybranego pola, która będzie wyświetlana jeśli wartość nie została jeszcze zapisana w bazie danych',
   visibility_tooltip:
-    'Widoczność pola w API. Musi być potęgą 2. Use  1 to Public access, 2 for Authorized, 4 for Admin, and rest is up to you',
+    'Widoczność pola dla API. Wartość 1 - publicznie widoczne, 2 - widoczne dla zalogowanych, 4 - widoczne dla administratora.',
   'available-validation-rules': 'dostępne metody walidacji',
+  'available-validation-rules-tooltip':
+    'Walidacja wybranego pola. Przykładowo, jeśli chcemy, aby pole było wymagane to w edytorze JSON musimy podać wartość: ["required"]',
   Products: 'Produkty',
   free: 'darmowy',
   free_capi: 'Darmowy',
@@ -604,4 +610,9 @@ export default {
   'Course imported successfully': 'Kurs został zaimportowany',
   'Course updated successfully': 'Kurs został zaktualizowany',
   'Export created': 'Poprawnie wyeksportowano plik',
+  'model.boolean': 'Pole jednokrotnego wyboru',
+  'model.number': 'Pole numeryczne',
+  'model.varchar': 'Pole tekstowe (varchar)',
+  'model.text': 'Pole tekstowe',
+  'model.json': 'JSON',
 };


### PR DESCRIPTION
[WC-872]
Add translations for field types in ModelField modal form.
Changed some translations to be more readable.

https://escl24.atlassian.net/browse/WC-872

[WC-872]: https://escl24.atlassian.net/browse/WC-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ