### PR TITLE
Add app store and play store fields in product

### DIFF
--- a/src/consts/packages.ts
+++ b/src/consts/packages.ts
@@ -54,6 +54,7 @@ enum PACKAGES {
   Youtube = 'escolalms/youtube',
   Recommender = 'escolalms/recommender',
   Dictionary = 'escolalms/dictionaries',
+  RevenuecatIntegration = 'escolalms/revenuecat-integration',
 }
 
 export default PACKAGES;

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -898,4 +898,8 @@ export default {
     'Czas trwania okresu próbnego określony liczbą w dniach, miesiącach lub latach',
   import_dictionary: 'Importuj słownik',
   course_fields: 'Dodatkowe pola',
+  app_store: 'Identyfikator w App Store',
+  app_store_tooltip: 'Identyfikator produktu w App Store dla płatności mobilnej',
+  play_store: 'Identyfikator w Play Store',
+  play_store_tooltip: 'Identyfikator produktu w Play Store dla płatności mobilnej',
 };

--- a/src/pages/Products/components/form.tsx
+++ b/src/pages/Products/components/form.tsx
@@ -25,6 +25,8 @@ import TagsInput from '@/components/TagsInput';
 import TemplateManuallyTriggerForProduct from '@/components/TemplateManuallyTrigger/forProduct';
 import UserSubmissions from '@/components/UsersSubmissions';
 import WysiwygMarkdown from '@/components/WysiwygMarkdown';
+import PACKAGES from '@/consts/packages';
+import { createHavePackageInstalled } from '@/utils/access';
 import { categoriesArrToIds, tagsArrToIds } from '@/utils/utils';
 import { ProFormSelect } from '@ant-design/pro-components';
 import ProTable from '@ant-design/pro-table';
@@ -117,6 +119,9 @@ const ProductsForm: React.FC<{
   const [multiple, setMultiple] = useState<boolean>(false);
   const [productType, setProductType] = useState<ProductTypes>(ProductTypes.BUNDLE);
   const [hasTrial, setHasTrial] = useState<boolean>(false);
+  const havePackageInstalled = useCallback(createHavePackageInstalled(initialState?.packages), [
+    initialState?.packages,
+  ]);
 
   useEffect(() => {
     if (productable && productable.class_id && productable.class_type) {
@@ -164,6 +169,8 @@ const ProductsForm: React.FC<{
           productables: response.data.productables
             ? transformProductablesFromAPI(response.data.productables as API.ProductProductable[])
             : [],
+          app_store: response.data.fields?.in_app_purchase_ids?.revenuecat?.app_store,
+          play_store: response.data.fields?.in_app_purchase_ids?.revenuecat?.play_store,
         };
         if (response.data && response?.data?.productables) {
           setProductableType(response?.data?.productables[0]?.productable_type);
@@ -212,6 +219,8 @@ const ProductsForm: React.FC<{
           Omit<EscolaLms.Cart.Http.Requests.Admin.ProductCreateRequest, 'related_products'> & {
             productables: string[] | string;
             related_products: EscolaLms.Cart.Models.Product[] | number[];
+            app_store: string;
+            play_store: string;
           },
       ) => {
         const related_products = values.related_products?.every(
@@ -230,6 +239,14 @@ const ProductsForm: React.FC<{
               )
             : undefined,
           ...(values.related_products ? { related_products } : {}),
+          fields: {
+            in_app_purchase_ids: {
+              revenuecat: {
+                app_store: values.app_store,
+                play_store: values.play_store,
+              }
+            }
+          }
         };
 
         let response: API.DefaultResponse<EscolaLms.Cart.Models.Product>;
@@ -683,6 +700,30 @@ const ProductsForm: React.FC<{
                 defaultMessage: 'teaser_url',
               })}
             />
+            {havePackageInstalled(PACKAGES.RevenuecatIntegration) && (
+              <>
+                <ProFormText
+                  width="sm"
+                  name="app_store"
+                  label={<FormattedMessage id="app_store" />}
+                  tooltip={<FormattedMessage id="app_store_tooltip" />}
+                  placeholder={intl.formatMessage({
+                    id: 'app_store',
+                    defaultMessage: 'app_store',
+                  })}
+                />
+                <ProFormText
+                  width="sm"
+                  name="play_store"
+                  label={<FormattedMessage id="play_store" />}
+                  tooltip={<FormattedMessage id="play_store_tooltip" />}
+                  placeholder={intl.formatMessage({
+                    id: 'play_store',
+                    defaultMessage: 'play_store',
+                  })}
+                />
+              </>
+            )}
           </ProForm.Group>{' '}
           <ProForm.Item
             shouldUpdate

--- a/src/services/escola-lms/products.ts
+++ b/src/services/escola-lms/products.ts
@@ -38,7 +38,16 @@ export async function createProduct(
 
 /**  GET /api/admin/products/:id */
 export async function getProduct(id: number, options?: AxiosRequestConfig) {
-  return request<API.DefaultResponse<EscolaLms.Cart.Models.Product & { has_trial?: boolean }>>(`/api/admin/products/${id}`, {
+  return request<
+    API.DefaultResponse<
+      EscolaLms.Cart.Models.Product & {
+        has_trial?: boolean;
+        fields?: {
+          in_app_purchase_ids?: { revenuecat?: { app_store?: string; play_store?: string } };
+        };
+      }
+    >
+  >(`/api/admin/products/${id}`, {
     method: 'GET',
     ...(options || {}),
   });


### PR DESCRIPTION
Add app store and play store fields in product available if revenuecat-integration package installed.