### PR TITLE
AN-8: subject gradebook for quiz/project grades

### DIFF
--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
@@ -1,5 +1,6 @@
 import { Context } from '@/components/ProgramForm/Context';
-import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
+// DEFAULT_GRADE_WEIGHT re-imported when the weight field is restored (see the topic forms).
+import { GRADEBOOK_FIELDS } from '@/consts/gradebook';
 import { getFormData } from '@/services/api';
 import { getTopic } from '@/services/escola-lms/course';
 import { TopicType } from '@/services/escola-lms/enums';
@@ -185,21 +186,22 @@ export const Topic: React.FC = () => {
       values.value = 'theProject';
     }
 
-    // AN-8 gradebook flag + weight — quiz/project topics only. Fall back to the stored
-    // topicable value so an untouched flag/weight isn't cleared on partial edits.
+    // AN-8 gradebook flag — quiz/project topics only. Fall back to the stored topicable
+    // value so an untouched flag isn't cleared on partial edits.
     if (topic.topicable_type === TopicType.GiftQuiz || topic.topicable_type === TopicType.Project) {
       const topicable = topics.topicable as
         | { counts_to_grade?: boolean; grade_weight?: number }
         | undefined;
-      const addToGradebook = Boolean(values[GRADEBOOK_FIELDS.flag] ?? topicable?.counts_to_grade);
-      values[GRADEBOOK_FIELDS.flag] = addToGradebook ? 1 : 0;
-      if (addToGradebook) {
-        const weight = Number(values[GRADEBOOK_FIELDS.weight] ?? topicable?.grade_weight);
-        values[GRADEBOOK_FIELDS.weight] =
-          Number.isFinite(weight) && weight > 0 ? weight : DEFAULT_GRADE_WEIGHT;
-      } else {
-        delete values[GRADEBOOK_FIELDS.weight];
-      }
+      const countsToGrade = Boolean(values[GRADEBOOK_FIELDS.flag] ?? topicable?.counts_to_grade);
+      values[GRADEBOOK_FIELDS.flag] = countsToGrade ? 1 : 0;
+      // AN-8: grade weight hidden for now — not serialized until the field is restored.
+      // if (countsToGrade) {
+      //   const weight = Number(values[GRADEBOOK_FIELDS.weight] ?? topicable?.grade_weight);
+      //   values[GRADEBOOK_FIELDS.weight] =
+      //     Number.isFinite(weight) && weight > 0 ? weight : DEFAULT_GRADE_WEIGHT;
+      // } else {
+      //   delete values[GRADEBOOK_FIELDS.weight];
+      // }
     }
 
     const formData = getFormData(values);

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
@@ -1,4 +1,5 @@
 import { Context } from '@/components/ProgramForm/Context';
+import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
 import { getFormData } from '@/services/api';
 import { getTopic } from '@/services/escola-lms/course';
 import { TopicType } from '@/services/escola-lms/enums';
@@ -171,7 +172,7 @@ export const Topic: React.FC = () => {
   );
 
   const onFormSubmit = useCallback(() => {
-    const values = {
+    const values: Record<string, any> = {
       ...topics,
       active: topics.active ? 1 : 0,
       preview: topics.preview ? 1 : 0,
@@ -182,6 +183,23 @@ export const Topic: React.FC = () => {
 
     if (topicCanHaveEmptyValue(topic.topicable_type) && !values.value) {
       values.value = 'theProject';
+    }
+
+    // AN-8 gradebook flag + weight — quiz/project topics only. Fall back to the stored
+    // topicable value so an untouched flag/weight isn't cleared on partial edits.
+    if (topic.topicable_type === TopicType.GiftQuiz || topic.topicable_type === TopicType.Project) {
+      const topicable = topics.topicable as
+        | { add_to_gradebook?: boolean; grade_weight?: number }
+        | undefined;
+      const addToGradebook = Boolean(values[GRADEBOOK_FIELDS.flag] ?? topicable?.add_to_gradebook);
+      values[GRADEBOOK_FIELDS.flag] = addToGradebook ? 1 : 0;
+      if (addToGradebook) {
+        const weight = Number(values[GRADEBOOK_FIELDS.weight] ?? topicable?.grade_weight);
+        values[GRADEBOOK_FIELDS.weight] =
+          Number.isFinite(weight) && weight > 0 ? weight : DEFAULT_GRADE_WEIGHT;
+      } else {
+        delete values[GRADEBOOK_FIELDS.weight];
+      }
     }
 
     const formData = getFormData(values);
@@ -279,7 +297,7 @@ export const Topic: React.FC = () => {
           )}
           {type && type === TopicType.Project && (
             <Project
-              onChange={(value) => updateValue('notify_users' as keyof API.Topic, value)}
+              onChange={(key, value) => updateValue(key as keyof API.Topic, value)}
               topicable={topic.topicable as API.TopicProject['topicable']}
             />
           )}

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
@@ -189,9 +189,9 @@ export const Topic: React.FC = () => {
     // topicable value so an untouched flag/weight isn't cleared on partial edits.
     if (topic.topicable_type === TopicType.GiftQuiz || topic.topicable_type === TopicType.Project) {
       const topicable = topics.topicable as
-        | { add_to_gradebook?: boolean; grade_weight?: number }
+        | { counts_to_grade?: boolean; grade_weight?: number }
         | undefined;
-      const addToGradebook = Boolean(values[GRADEBOOK_FIELDS.flag] ?? topicable?.add_to_gradebook);
+      const addToGradebook = Boolean(values[GRADEBOOK_FIELDS.flag] ?? topicable?.counts_to_grade);
       values[GRADEBOOK_FIELDS.flag] = addToGradebook ? 1 : 0;
       if (addToGradebook) {
         const weight = Number(values[GRADEBOOK_FIELDS.weight] ?? topicable?.grade_weight);

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
@@ -22,7 +22,7 @@ export const GiftQuiz: React.FC<{
 }> = ({ topicable, onAdded, onRemoved, onEdited, onChange }) => {
   const intl = useIntl();
   const [addToGradebook, setAddToGradebook] = useState<boolean>(
-    Boolean(topicable?.add_to_gradebook),
+    Boolean(topicable?.counts_to_grade),
   );
 
   return (
@@ -32,7 +32,7 @@ export const GiftQuiz: React.FC<{
           max_attempts: topicable ? topicable.max_attempts : undefined,
           max_execution_time: topicable ? topicable.max_execution_time : undefined,
           min_pass_score: topicable ? topicable.min_pass_score : undefined,
-          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.add_to_gradebook),
+          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.counts_to_grade),
           [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
         }}
         onValuesChange={(values) => {
@@ -78,13 +78,11 @@ export const GiftQuiz: React.FC<{
         <ProFormGroup>
           <ProFormSwitch
             name={GRADEBOOK_FIELDS.flag}
-            label={
-              <FormattedMessage id="add_to_gradebook" defaultMessage="Add grade to gradebook" />
-            }
+            label={<FormattedMessage id="counts_to_grade" defaultMessage="Show in final grade" />}
             tooltip={
               <FormattedMessage
-                id="add_to_gradebook_tooltip"
-                defaultMessage="When enabled, this grade is counted in the subject gradebook."
+                id="counts_to_grade_tooltip"
+                defaultMessage="When enabled, this item appears in the final grade and qualifies for a partial grade."
               />
             }
           />

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
@@ -1,18 +1,29 @@
 import { Table } from '@/components/GiftQuizQuestions/table';
-import ProForm, { ProFormDigit, ProFormGroup } from '@ant-design/pro-form';
+import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
+import ProForm, { ProFormDigit, ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
 import { Divider } from 'antd';
 import Typography from 'antd/lib/typography/Typography';
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
+
+type QuizChangeKey =
+  | 'max_attempts'
+  | 'max_execution_time'
+  | 'min_pass_score'
+  | typeof GRADEBOOK_FIELDS.flag
+  | typeof GRADEBOOK_FIELDS.weight;
 
 export const GiftQuiz: React.FC<{
   topicable: API.TopicQuiz['topicable'];
-  onChange: (key: 'max_attempts' | 'max_execution_time', value: number | null) => void;
+  onChange: (key: QuizChangeKey, value: number | boolean | null) => void;
   onAdded?: () => void;
   onRemoved?: () => void;
   onEdited?: () => void;
 }> = ({ topicable, onAdded, onRemoved, onEdited, onChange }) => {
   const intl = useIntl();
+  const [addToGradebook, setAddToGradebook] = useState<boolean>(
+    Boolean(topicable?.add_to_gradebook),
+  );
 
   return (
     <Fragment>
@@ -21,12 +32,16 @@ export const GiftQuiz: React.FC<{
           max_attempts: topicable ? topicable.max_attempts : undefined,
           max_execution_time: topicable ? topicable.max_execution_time : undefined,
           min_pass_score: topicable ? topicable.min_pass_score : undefined,
+          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.add_to_gradebook),
+          [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
         }}
         onValuesChange={(values) => {
-          const key = Object.keys(values)[0] as 'max_attempts' | 'max_execution_time';
-          if (key) {
-            onChange(key, values[key]);
+          const key = Object.keys(values)[0] as QuizChangeKey;
+          if (!key) return;
+          if (key === GRADEBOOK_FIELDS.flag) {
+            setAddToGradebook(Boolean(values[key]));
           }
+          onChange(key, values[key]);
         }}
         submitter={false}
       >
@@ -59,6 +74,52 @@ export const GiftQuiz: React.FC<{
               defaultMessage: 'min_pass_score',
             })}
           />
+        </ProFormGroup>
+        <ProFormGroup>
+          <ProFormSwitch
+            name={GRADEBOOK_FIELDS.flag}
+            label={
+              <FormattedMessage id="add_to_gradebook" defaultMessage="Add grade to gradebook" />
+            }
+            tooltip={
+              <FormattedMessage
+                id="add_to_gradebook_tooltip"
+                defaultMessage="When enabled, this grade is counted in the subject gradebook."
+              />
+            }
+          />
+          {addToGradebook && (
+            <ProFormDigit
+              name={GRADEBOOK_FIELDS.weight}
+              label={<FormattedMessage id="grade_weight" defaultMessage="Grade weight" />}
+              tooltip={
+                <FormattedMessage id="grade_weight_tooltip" defaultMessage="Default weight is 1." />
+              }
+              extra={
+                <FormattedMessage
+                  id="grade_weight_default_hint"
+                  defaultMessage="Default weight is 1."
+                />
+              }
+              min={0}
+              fieldProps={{ step: 0.25, precision: 2 }}
+              rules={[
+                {
+                  validator: (_rule, value) =>
+                    value === undefined || value === null || Number(value) > 0
+                      ? Promise.resolve()
+                      : Promise.reject(
+                          new Error(
+                            intl.formatMessage({
+                              id: 'grade_weight_must_be_positive',
+                              defaultMessage: 'Weight must be greater than 0.',
+                            }),
+                          ),
+                        ),
+                },
+              ]}
+            />
+          )}
         </ProFormGroup>
       </ProForm>
 

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
@@ -1,17 +1,19 @@
 import { Table } from '@/components/GiftQuizQuestions/table';
-import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
+// DEFAULT_GRADE_WEIGHT re-imported when the weight field below is restored.
+import { GRADEBOOK_FIELDS } from '@/consts/gradebook';
 import ProForm, { ProFormDigit, ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
 import { Divider } from 'antd';
 import Typography from 'antd/lib/typography/Typography';
-import React, { Fragment, useState } from 'react';
+// useState re-imported when the weight field below is restored.
+import React, { Fragment } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 type QuizChangeKey =
   | 'max_attempts'
   | 'max_execution_time'
   | 'min_pass_score'
-  | typeof GRADEBOOK_FIELDS.flag
-  | typeof GRADEBOOK_FIELDS.weight;
+  // | typeof GRADEBOOK_FIELDS.weight — hidden with the weight field, restore together
+  | typeof GRADEBOOK_FIELDS.flag;
 
 export const GiftQuiz: React.FC<{
   topicable: API.TopicQuiz['topicable'];
@@ -21,9 +23,10 @@ export const GiftQuiz: React.FC<{
   onEdited?: () => void;
 }> = ({ topicable, onAdded, onRemoved, onEdited, onChange }) => {
   const intl = useIntl();
-  const [addToGradebook, setAddToGradebook] = useState<boolean>(
-    Boolean(topicable?.counts_to_grade),
-  );
+  // AN-8: grade weight hidden for now — this state only toggled the weight field's visibility.
+  // const [addToGradebook, setAddToGradebook] = useState<boolean>(
+  //   Boolean(topicable?.counts_to_grade),
+  // );
 
   return (
     <Fragment>
@@ -33,14 +36,14 @@ export const GiftQuiz: React.FC<{
           max_execution_time: topicable ? topicable.max_execution_time : undefined,
           min_pass_score: topicable ? topicable.min_pass_score : undefined,
           [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.counts_to_grade),
-          [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
+          // [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
         }}
         onValuesChange={(values) => {
           const key = Object.keys(values)[0] as QuizChangeKey;
           if (!key) return;
-          if (key === GRADEBOOK_FIELDS.flag) {
-            setAddToGradebook(Boolean(values[key]));
-          }
+          // if (key === GRADEBOOK_FIELDS.flag) {
+          //   setAddToGradebook(Boolean(values[key]));
+          // }
           onChange(key, values[key]);
         }}
         submitter={false}
@@ -86,6 +89,8 @@ export const GiftQuiz: React.FC<{
               />
             }
           />
+          {/* AN-8: grade weight hidden until its backend lands — restore together with the
+              state / initialValue / import / type union commented above.
           {addToGradebook && (
             <ProFormDigit
               name={GRADEBOOK_FIELDS.weight}
@@ -117,7 +122,7 @@ export const GiftQuiz: React.FC<{
                 },
               ]}
             />
-          )}
+          )} */}
         </ProFormGroup>
       </ProForm>
 

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
@@ -1,31 +1,49 @@
 import UserSelect from '@/components/UserSelect';
-import ProForm from '@ant-design/pro-form';
-import React, { useCallback } from 'react';
-import { FormattedMessage } from 'umi';
+import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
+import ProForm, { ProFormDigit, ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
+import React, { useCallback, useState } from 'react';
+import { FormattedMessage, useIntl } from 'umi';
 
 type SelectValue = string | number | string[] | number[];
 
-interface FormValues {
-  notify_users: SelectValue;
-}
+type ProjectChangeKey =
+  | 'notify_users'
+  | typeof GRADEBOOK_FIELDS.flag
+  | typeof GRADEBOOK_FIELDS.weight;
+
+type ProjectChangeValue = SelectValue | boolean | number | null;
 
 interface Props {
-  onChange: (value: SelectValue) => void;
+  onChange: (key: ProjectChangeKey, value: ProjectChangeValue) => void;
   topicable: API.TopicProject['topicable'];
 }
 
 export const Project: React.FC<Props> = ({ onChange, topicable }) => {
-  const onValuesChange = useCallback((values: FormValues) => {
-    const key = Object.keys(values)[0];
-    if (key) {
-      onChange(values[key as keyof typeof values]);
-    }
-  }, []);
+  const intl = useIntl();
+  const [addToGradebook, setAddToGradebook] = useState<boolean>(
+    Boolean(topicable?.add_to_gradebook),
+  );
+
+  const onValuesChange = useCallback(
+    (values: Record<string, ProjectChangeValue>) => {
+      const key = Object.keys(values)[0] as ProjectChangeKey;
+      if (!key) return;
+      if (key === GRADEBOOK_FIELDS.flag) {
+        setAddToGradebook(Boolean(values[key]));
+      }
+      onChange(key, values[key]);
+    },
+    [onChange],
+  );
 
   return (
     <React.Fragment>
       <ProForm
-        initialValues={{ notify_users: topicable?.notify_users ?? [] }}
+        initialValues={{
+          notify_users: topicable?.notify_users ?? [],
+          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.add_to_gradebook),
+          [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
+        }}
         onValuesChange={onValuesChange}
         submitter={false}
       >
@@ -41,6 +59,52 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
         >
           <UserSelect multiple />
         </ProForm.Item>
+        <ProFormGroup>
+          <ProFormSwitch
+            name={GRADEBOOK_FIELDS.flag}
+            label={
+              <FormattedMessage id="add_to_gradebook" defaultMessage="Add grade to gradebook" />
+            }
+            tooltip={
+              <FormattedMessage
+                id="add_to_gradebook_tooltip"
+                defaultMessage="When enabled, this grade is counted in the subject gradebook."
+              />
+            }
+          />
+          {addToGradebook && (
+            <ProFormDigit
+              name={GRADEBOOK_FIELDS.weight}
+              label={<FormattedMessage id="grade_weight" defaultMessage="Grade weight" />}
+              tooltip={
+                <FormattedMessage id="grade_weight_tooltip" defaultMessage="Default weight is 1." />
+              }
+              extra={
+                <FormattedMessage
+                  id="grade_weight_default_hint"
+                  defaultMessage="Default weight is 1."
+                />
+              }
+              min={0}
+              fieldProps={{ step: 0.25, precision: 2 }}
+              rules={[
+                {
+                  validator: (_rule, value) =>
+                    value === undefined || value === null || Number(value) > 0
+                      ? Promise.resolve()
+                      : Promise.reject(
+                          new Error(
+                            intl.formatMessage({
+                              id: 'grade_weight_must_be_positive',
+                              defaultMessage: 'Weight must be greater than 0.',
+                            }),
+                          ),
+                        ),
+                },
+              ]}
+            />
+          )}
+        </ProFormGroup>
       </ProForm>
     </React.Fragment>
   );

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const Project: React.FC<Props> = ({ onChange, topicable }) => {
   const intl = useIntl();
   const [addToGradebook, setAddToGradebook] = useState<boolean>(
-    Boolean(topicable?.add_to_gradebook),
+    Boolean(topicable?.counts_to_grade),
   );
 
   const onValuesChange = useCallback(
@@ -41,7 +41,7 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
       <ProForm
         initialValues={{
           notify_users: topicable?.notify_users ?? [],
-          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.add_to_gradebook),
+          [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.counts_to_grade),
           [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
         }}
         onValuesChange={onValuesChange}
@@ -62,13 +62,11 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
         <ProFormGroup>
           <ProFormSwitch
             name={GRADEBOOK_FIELDS.flag}
-            label={
-              <FormattedMessage id="add_to_gradebook" defaultMessage="Add grade to gradebook" />
-            }
+            label={<FormattedMessage id="counts_to_grade" defaultMessage="Show in final grade" />}
             tooltip={
               <FormattedMessage
-                id="add_to_gradebook_tooltip"
-                defaultMessage="When enabled, this grade is counted in the subject gradebook."
+                id="counts_to_grade_tooltip"
+                defaultMessage="When enabled, this item appears in the final grade and qualifies for a partial grade."
               />
             }
           />

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/project.tsx
@@ -1,15 +1,19 @@
 import UserSelect from '@/components/UserSelect';
-import { DEFAULT_GRADE_WEIGHT, GRADEBOOK_FIELDS } from '@/consts/gradebook';
-import ProForm, { ProFormDigit, ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
-import React, { useCallback, useState } from 'react';
-import { FormattedMessage, useIntl } from 'umi';
+// DEFAULT_GRADE_WEIGHT re-imported when the weight field below is restored.
+import { GRADEBOOK_FIELDS } from '@/consts/gradebook';
+// ProFormDigit re-imported when the weight field below is restored.
+import ProForm, { ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
+// useState re-imported when the weight field below is restored.
+import React, { useCallback } from 'react';
+// useIntl re-imported when the weight field below is restored.
+import { FormattedMessage } from 'umi';
 
 type SelectValue = string | number | string[] | number[];
 
 type ProjectChangeKey =
   | 'notify_users'
-  | typeof GRADEBOOK_FIELDS.flag
-  | typeof GRADEBOOK_FIELDS.weight;
+  // | typeof GRADEBOOK_FIELDS.weight — hidden with the weight field, restore together
+  | typeof GRADEBOOK_FIELDS.flag;
 
 type ProjectChangeValue = SelectValue | boolean | number | null;
 
@@ -19,18 +23,19 @@ interface Props {
 }
 
 export const Project: React.FC<Props> = ({ onChange, topicable }) => {
-  const intl = useIntl();
-  const [addToGradebook, setAddToGradebook] = useState<boolean>(
-    Boolean(topicable?.counts_to_grade),
-  );
+  // AN-8: grade weight hidden for now — intl + this state only served the weight field.
+  // const intl = useIntl();
+  // const [addToGradebook, setAddToGradebook] = useState<boolean>(
+  //   Boolean(topicable?.counts_to_grade),
+  // );
 
   const onValuesChange = useCallback(
     (values: Record<string, ProjectChangeValue>) => {
       const key = Object.keys(values)[0] as ProjectChangeKey;
       if (!key) return;
-      if (key === GRADEBOOK_FIELDS.flag) {
-        setAddToGradebook(Boolean(values[key]));
-      }
+      // if (key === GRADEBOOK_FIELDS.flag) {
+      //   setAddToGradebook(Boolean(values[key]));
+      // }
       onChange(key, values[key]);
     },
     [onChange],
@@ -42,7 +47,7 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
         initialValues={{
           notify_users: topicable?.notify_users ?? [],
           [GRADEBOOK_FIELDS.flag]: Boolean(topicable?.counts_to_grade),
-          [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
+          // [GRADEBOOK_FIELDS.weight]: topicable?.grade_weight ?? DEFAULT_GRADE_WEIGHT,
         }}
         onValuesChange={onValuesChange}
         submitter={false}
@@ -70,6 +75,8 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
               />
             }
           />
+          {/* AN-8: grade weight hidden until its backend lands — restore together with the
+              state / initialValue / import / type union commented above.
           {addToGradebook && (
             <ProFormDigit
               name={GRADEBOOK_FIELDS.weight}
@@ -101,7 +108,7 @@ export const Project: React.FC<Props> = ({ onChange, topicable }) => {
                 },
               ]}
             />
-          )}
+          )} */}
         </ProFormGroup>
       </ProForm>
     </React.Fragment>

--- a/src/consts/gradebook.ts
+++ b/src/consts/gradebook.ts
@@ -1,0 +1,31 @@
+/**
+ * AN-8 — Subject gradebook (quiz/project grades).
+ *
+ * Single source of truth for the *assumed* backend contract used by the gradebook
+ * feature. The backend endpoints are delivered as separate tasks; until they land
+ * these values are placeholders. When the real API is available, adjust the field
+ * names / endpoint paths here (and the shapes in `services/escola-lms/gradebook.ts`)
+ * — the UI does not hardcode them anywhere else.
+ */
+
+/** Field names sent with a quiz/project topic on create/edit. */
+export const GRADEBOOK_FIELDS = {
+  /** boolean — whether the resulting grade is counted in the subject gradebook */
+  flag: 'add_to_gradebook',
+  /** number (decimals allowed, > 0) — weight the grade carries in the gradebook */
+  weight: 'grade_weight',
+} as const;
+
+/**
+ * Default weight applied on the FE (prefill) when the flag is on but no weight is
+ * entered. The BE is expected to treat a missing weight as this same default.
+ */
+export const DEFAULT_GRADE_WEIGHT = 1;
+
+/** Placeholder REST endpoints for reading gradebook data. Adjust when the API lands. */
+export const GRADEBOOK_ENDPOINTS = {
+  /** Per-student, per-course quiz/project grades + pass/fail (FinalGradesDetails). */
+  studentCourseGrades: '/api/admin/gradebook/student-grades',
+  /** Group-level flagged quiz/project grades (ClassRegister gradebook columns). */
+  groupGradebook: '/api/admin/gradebook/group-grades',
+} as const;

--- a/src/consts/gradebook.ts
+++ b/src/consts/gradebook.ts
@@ -10,7 +10,9 @@
  *   content API (courses package) for both quiz and project topicables, and quizzes
  *   also accept it on `PUT /api/admin/gift-quizes/{id}`. Default false.
  * - `weight` (`grade_weight`) and the read endpoints below remain PLACEHOLDERS,
- *   pending their separate backend tasks.
+ *   pending their separate backend tasks. The weight input is currently commented
+ *   out in the quiz/project topic forms (hidden until its backend lands); this field
+ *   name is kept so it can be uncommented in place.
  */
 
 /** Field names sent with a quiz/project topic on create/edit. */

--- a/src/consts/gradebook.ts
+++ b/src/consts/gradebook.ts
@@ -1,18 +1,26 @@
 /**
  * AN-8 — Subject gradebook (quiz/project grades).
  *
- * Single source of truth for the *assumed* backend contract used by the gradebook
- * feature. The backend endpoints are delivered as separate tasks; until they land
- * these values are placeholders. When the real API is available, adjust the field
- * names / endpoint paths here (and the shapes in `services/escola-lms/gradebook.ts`)
- * — the UI does not hardcode them anywhere else.
+ * Single source of truth for the backend contract used by the gradebook feature.
+ * The UI does not hardcode these field names / endpoint paths anywhere else — adjust
+ * them here (and the shapes in `services/escola-lms/gradebook.ts`) when they change.
+ *
+ * Status of the contract:
+ * - `flag` (`counts_to_grade`) is DELIVERED. It is accepted/returned by the Topic
+ *   content API (courses package) for both quiz and project topicables, and quizzes
+ *   also accept it on `PUT /api/admin/gift-quizes/{id}`. Default false.
+ * - `weight` (`grade_weight`) and the read endpoints below remain PLACEHOLDERS,
+ *   pending their separate backend tasks.
  */
 
 /** Field names sent with a quiz/project topic on create/edit. */
 export const GRADEBOOK_FIELDS = {
-  /** boolean — whether the resulting grade is counted in the subject gradebook */
-  flag: 'add_to_gradebook',
-  /** number (decimals allowed, > 0) — weight the grade carries in the gradebook */
+  /**
+   * boolean (DELIVERED) — whether this quiz/project appears in the final grade and
+   * qualifies for a partial grade. Checkbox "Show in final grade". Default false.
+   */
+  flag: 'counts_to_grade',
+  /** number (decimals allowed, > 0), PLACEHOLDER — weight the grade carries in the gradebook */
   weight: 'grade_weight',
 } as const;
 

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -912,4 +912,21 @@ export default {
     'The duration of the trial period expressed as a number in days, months or years',
   import_dictionary: 'Import dictionary',
   course_fields: 'Additional fields',
+
+  // AN-8 — subject gradebook (quiz/project grades)
+  gradebook: 'Gradebook',
+  gradebookColumnTitle: '{title} (×{weight})',
+  add_to_gradebook: 'Add grade to gradebook',
+  add_to_gradebook_tooltip: 'When enabled, this grade is counted in the subject gradebook.',
+  grade_weight: 'Grade weight',
+  grade_weight_tooltip: 'Default weight is 1.',
+  grade_weight_default_hint: 'Default weight is 1.',
+  grade_weight_must_be_positive: 'Weight must be greater than 0.',
+  'gradebook.passed': 'Passed',
+  'gradebook.failed': 'Failed',
+  'gradebook.pass_fail': 'Pass / fail',
+  'gradebook.no_course_grades': 'No quiz or project grades yet.',
+  'gradebook.course_grades_title': 'Quiz and project grades',
+  'gradebook.type.GiftQuiz': 'Quiz',
+  'gradebook.type.Project': 'Project',
 };

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -916,8 +916,9 @@ export default {
   // AN-8 — subject gradebook (quiz/project grades)
   gradebook: 'Gradebook',
   gradebookColumnTitle: '{title} (×{weight})',
-  add_to_gradebook: 'Add grade to gradebook',
-  add_to_gradebook_tooltip: 'When enabled, this grade is counted in the subject gradebook.',
+  counts_to_grade: 'Show in final grade',
+  counts_to_grade_tooltip:
+    'When enabled, this item appears in the final grade and qualifies for a partial grade.',
   grade_weight: 'Grade weight',
   grade_weight_tooltip: 'Default weight is 1.',
   grade_weight_default_hint: 'Default weight is 1.',

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -918,8 +918,9 @@ export default {
   // AN-8 — dziennik ocen przedmiotu (oceny z quizów/projektów)
   gradebook: 'Dziennik ocen',
   gradebookColumnTitle: '{title} (×{weight})',
-  add_to_gradebook: 'Dodaj ocenę do dziennika',
-  add_to_gradebook_tooltip: 'Gdy włączone, ocena jest liczona w dzienniku ocen przedmiotu.',
+  counts_to_grade: 'Pokaż w ocenie końcowej',
+  counts_to_grade_tooltip:
+    'Gdy włączone, pozycja pojawia się w ocenie końcowej i kwalifikuje się do oceny cząstkowej.',
   grade_weight: 'Waga oceny',
   grade_weight_tooltip: 'Domyślna waga to 1.',
   grade_weight_default_hint: 'Domyślna waga to 1.',

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -914,4 +914,21 @@ export default {
   app_store_tooltip: 'Identyfikator produktu w App Store dla płatności mobilnej',
   play_store: 'Identyfikator w Play Store',
   play_store_tooltip: 'Identyfikator produktu w Play Store dla płatności mobilnej',
+
+  // AN-8 — dziennik ocen przedmiotu (oceny z quizów/projektów)
+  gradebook: 'Dziennik ocen',
+  gradebookColumnTitle: '{title} (×{weight})',
+  add_to_gradebook: 'Dodaj ocenę do dziennika',
+  add_to_gradebook_tooltip: 'Gdy włączone, ocena jest liczona w dzienniku ocen przedmiotu.',
+  grade_weight: 'Waga oceny',
+  grade_weight_tooltip: 'Domyślna waga to 1.',
+  grade_weight_default_hint: 'Domyślna waga to 1.',
+  grade_weight_must_be_positive: 'Waga musi być większa niż 0.',
+  'gradebook.passed': 'Zaliczony',
+  'gradebook.failed': 'Niezaliczony',
+  'gradebook.pass_fail': 'Zaliczenie',
+  'gradebook.no_course_grades': 'Brak ocen z quizów i projektów.',
+  'gradebook.course_grades_title': 'Oceny z quizów i projektów',
+  'gradebook.type.GiftQuiz': 'Quiz',
+  'gradebook.type.Project': 'Projekt',
 };

--- a/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
+++ b/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/services/escola-lms/attendances';
 import { AttendanceValue } from '@/services/escola-lms/enums';
 import { getExams as fetchExams } from '@/services/escola-lms/exams';
+import { getGroupGradebook as fetchGroupGradebook } from '@/services/escola-lms/gradebook';
 import {
   getGradeTerms as fetchGradeTerms,
   getGroupFinalGrades as fetchGroupFinalGrades,
@@ -37,9 +38,11 @@ import {
   getExamsCols,
   getFinalGrades,
   getFinalGradesCols,
+  getGradebookCols,
   getStudentAttendances,
   getStudentExamResults,
   getStudentFinalGrades,
+  getStudentGradebookGrades,
   isGroupStudent,
 } from './utils';
 
@@ -250,7 +253,18 @@ export const ClassRegister: React.FC = () => {
             }
             setSelectedGroupName(selectedGroup.label);
 
-            /* Group-wide source of truth for the bulk "mark group" summary row:
+            // AN-8 gradebook (flagged quiz/project grades). Fetched independently with a
+          // fallback so a not-yet-available endpoint never breaks the class register.
+          const gradebookRes = await fetchGroupGradebook({
+            group_id,
+            semester_subject_id,
+          }).catch(() => null);
+          const gradebook: API.GroupGradebook =
+            gradebookRes?.success && gradebookRes.data
+              ? gradebookRes.data
+              : { columns: [], students: [] };
+
+          /* Group-wide source of truth for the bulk "mark group" summary row:
              the full roster (teacher-filtered, but independent of the name
              search) plus the current attendance value per schedule/student. */
             const groupStudents = studentUserGroupRes.data.users.filter(
@@ -287,19 +301,21 @@ export const ClassRegister: React.FC = () => {
               gradeTermsRes.data,
               subjectGradeScalesRes.data,
             );
+          const gradebookCols = getGradebookCols(gradebook.columns);
 
             setDynamicCols([
               attendanceCols,
               examsCols,
-              finalGradeCols,
-              {
-                title: <FormattedMessage id="proposed_grade" />,
-                hideInSearch: true,
-                dataIndex: 'proposed_grade',
-                align: 'center',
-                width: 100,
-              },
-            ]);
+              gradebookCols,
+            finalGradeCols,
+            {
+              title: <FormattedMessage id="proposed_grade" />,
+              hideInSearch: true,
+              dataIndex: 'proposed_grade',
+              align: 'center',
+              width: 100,
+            },
+          ]);
 
             const data = studentUserGroupRes.data.users
               .reduce<ClassRegisterTableItem[]>(
@@ -333,13 +349,16 @@ export const ClassRegister: React.FC = () => {
 
                   const finalGrades = getFinalGrades(studentFinalGrades);
 
-                  return [
-                    ...acc,
-                    {
-                      id,
-                      full_name: studentFullName,
-                      ...studentAttendances,
-                      ...studentExamResults,
+                  const gradebookGrades = getStudentGradebookGrades(gradebook, id);
+
+                return [
+                  ...acc,
+                  {
+                    id,
+                    full_name: studentFullName,
+                    ...studentAttendances,
+                    ...studentExamResults,
+                    ...gradebookGrades,
                       ...finalGrades,
                       proposed_grade,
                       final_grades: studentFinalGrades,

--- a/src/pages/TeacherSubjects/components/ClassRegister/types.ts
+++ b/src/pages/TeacherSubjects/components/ClassRegister/types.ts
@@ -14,7 +14,13 @@ export type ClassRegisterTableItemFinalGrade = Record<
   API.FinalGradeItemGrade
 >;
 
+export type ClassRegisterTableItemGradebook = Record<
+  `gradebook-${string}`,
+  API.GroupGradebookStudentGrade
+>;
+
 export type ClassRegisterTableItem = ClassRegisterTableItemBase &
   ClassRegisterTableItemAttendance &
   ClassRegisterTableItemExamResult &
-  ClassRegisterTableItemFinalGrade;
+  ClassRegisterTableItemFinalGrade &
+  ClassRegisterTableItemGradebook;

--- a/src/pages/TeacherSubjects/components/ClassRegister/utils.tsx
+++ b/src/pages/TeacherSubjects/components/ClassRegister/utils.tsx
@@ -3,7 +3,7 @@ import { DAY_FORMAT } from '@/consts/dates';
 import { ExamGradeType } from '@/services/escola-lms/enums';
 import { DeleteOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-table';
-import { Checkbox, Space, Table, Tooltip } from 'antd';
+import { Checkbox, Space, Table, Tooltip, Typography } from 'antd';
 import { format } from 'date-fns';
 import React from 'react';
 import { FormattedMessage } from 'umi';
@@ -15,6 +15,7 @@ import type {
   ClassRegisterTableItemAttendance,
   ClassRegisterTableItemExamResult,
   ClassRegisterTableItemFinalGrade,
+  ClassRegisterTableItemGradebook,
 } from './types';
 
 /* Attendance */
@@ -242,6 +243,50 @@ export const getFinalGradesCols = (
     ),
   })),
 });
+
+/* Gradebook (AN-8) — only flagged quiz/project items reach `columns` from the backend */
+export const getGradebookCols = (
+  gradebookColumns: API.GroupGradebookColumn[],
+): ProColumns<ClassRegisterTableItem> => {
+  const dynamicCols = gradebookColumns.map<ProColumns<ClassRegisterTableItem>>((col) => ({
+    dataIndex: `gradebook-${col.topic_id}`,
+    title: (
+      <FormattedMessage
+        id="gradebookColumnTitle"
+        defaultMessage="{title} (×{weight})"
+        values={{ title: col.topic_title, weight: col.grade_weight }}
+      />
+    ),
+    hideInSearch: true,
+    width: 120,
+    align: 'center',
+    render: (_n, record) => {
+      const item = record[`gradebook-${col.topic_id}`];
+      if (!item || item.grade === null || item.grade === undefined) return '-';
+      const textType =
+        item.passed === true ? 'success' : item.passed === false ? 'danger' : undefined;
+      return <Typography.Text type={textType}>{item.grade}</Typography.Text>;
+    },
+  }));
+
+  if (!dynamicCols.length)
+    return { title: <FormattedMessage id="gradebook" />, hideInSearch: true, hideInTable: true };
+
+  return { title: <FormattedMessage id="gradebook" />, hideInSearch: true, children: dynamicCols };
+};
+
+export const getStudentGradebookGrades = (
+  gradebook: API.GroupGradebook,
+  student_id: number,
+): ClassRegisterTableItemGradebook => {
+  const student = gradebook.students.find(({ user_id }) => user_id === student_id);
+  if (!student) return {};
+
+  return student.grades.reduce<ClassRegisterTableItemGradebook>(
+    (acc, grade) => ({ ...acc, [`gradebook-${grade.topic_id}`]: grade }),
+    {},
+  );
+};
 
 export const getStudentFinalGrades = (
   finalGrades: API.FinalGradeItem[],

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/StudentCourseGrades.tsx
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/StudentCourseGrades.tsx
@@ -1,0 +1,115 @@
+import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { Empty, Spin, Tag, Typography } from 'antd';
+import React from 'react';
+import { FormattedMessage } from 'umi';
+
+/**
+ * AN-8 — "Final grades" per-course tables for a single student.
+ *
+ * Renders one table per course listing that course's quiz/project grades plus
+ * pass/fail. This is a distinct component from the gradebook (ClassRegister),
+ * although both consume the same backend gradebook data.
+ */
+
+const PassFailTag: React.FC<{ passed: boolean | null }> = ({ passed }) => {
+  if (passed === null || passed === undefined) {
+    return <Tag>-</Tag>;
+  }
+  return passed ? (
+    <Tag color="success">
+      <FormattedMessage id="gradebook.passed" defaultMessage="Passed" />
+    </Tag>
+  ) : (
+    <Tag color="error">
+      <FormattedMessage id="gradebook.failed" defaultMessage="Failed" />
+    </Tag>
+  );
+};
+
+const columns: ProColumns<API.StudentCourseGrade>[] = [
+  {
+    title: <FormattedMessage id="name" />,
+    dataIndex: 'topic_title',
+  },
+  {
+    title: <FormattedMessage id="type" />,
+    dataIndex: 'topicable_type',
+    render: (_n, row) => (
+      <FormattedMessage
+        id={`gradebook.type.${row.topicable_type}`}
+        defaultMessage={row.topicable_type}
+      />
+    ),
+  },
+  {
+    title: <FormattedMessage id="grade" />,
+    dataIndex: 'grade',
+    render: (_n, row) => (row.grade === null || row.grade === undefined ? '-' : row.grade),
+  },
+  {
+    title: <FormattedMessage id="gradebook.pass_fail" defaultMessage="Pass / fail" />,
+    dataIndex: 'passed',
+    render: (_n, row) => <PassFailTag passed={row.passed} />,
+  },
+];
+
+const TABLE_PAGE_SIZE = 6;
+
+interface Props {
+  data?: API.StudentCourseGrades[];
+  loading: boolean;
+}
+
+export const StudentCourseGrades: React.FC<Props> = ({ data, loading }) => {
+  if (loading && !data) {
+    return <Spin />;
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Empty
+        description={
+          <FormattedMessage
+            id="gradebook.no_course_grades"
+            defaultMessage="No quiz or project grades yet."
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      {data.map((course) => (
+        <div key={course.course_id} style={{ marginBottom: '24px' }}>
+          <Typography.Text style={{ fontSize: '16px', fontWeight: 500 }}>
+            {course.course_title}
+          </Typography.Text>
+          <ProTable<API.StudentCourseGrade>
+            rowKey="topic_id"
+            search={false}
+            options={false}
+            pagination={{ pageSize: TABLE_PAGE_SIZE }}
+            dataSource={course.grades}
+            columns={columns}
+            cardProps={{ bodyStyle: { padding: 0 } }}
+            locale={{
+              emptyText: (
+                <Empty
+                  description={
+                    <FormattedMessage
+                      id="gradebook.no_course_grades"
+                      defaultMessage="No quiz or project grades yet."
+                    />
+                  }
+                />
+              ),
+            }}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default StudentCourseGrades;

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/hooks.ts
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/hooks.ts
@@ -2,6 +2,7 @@ import { getFlatTopics } from '@/components/ProgramForm/Context';
 import { groupAttendanceSchedule } from '@/services/escola-lms/attendances';
 import { course, getCourseStats, program } from '@/services/escola-lms/course';
 import { getExams } from '@/services/escola-lms/exams';
+import { getStudentCourseGrades } from '@/services/escola-lms/gradebook';
 import {
   getGradeTerms,
   getSubjectGradeScales,
@@ -201,6 +202,37 @@ export function useStudentExams(student_id: number, semester_subject_id: number 
   }, [student_id, semester_subject_id]);
 
   return { studentExams };
+}
+
+export function useStudentCourseGrades(
+  user_id: number,
+  group_id: number,
+  semester_subject_id: number | null,
+) {
+  const [courseGrades, setCourseGrades] = useState<FetchedData<API.StudentCourseGrades[]>>({
+    loading: false,
+  });
+
+  useEffect(() => {
+    setCourseGrades((prev) => ({ ...prev, loading: true }));
+    getStudentCourseGrades({
+      user_id,
+      group_id,
+      semester_subject_id: semester_subject_id ?? undefined,
+    })
+      .then((response) => {
+        if (response.success) {
+          setCourseGrades((prev) => ({ ...prev, data: response.data }));
+        }
+      })
+      // endpoint may not exist yet (placeholder) — fall back to empty state
+      .catch(() => undefined)
+      .finally(() => {
+        setCourseGrades((prev) => ({ ...prev, loading: false }));
+      });
+  }, [user_id, group_id, semester_subject_id]);
+
+  return { courseGrades };
 }
 
 export function useUserCoursesStats(group_id: number, user_id: number) {

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/index.tsx
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/index.tsx
@@ -11,9 +11,11 @@ import { UserCourseAttempts, UserProgress } from '@/components/CourseStatistics/
 import { DAY_FORMAT } from '@/consts/dates';
 import { createFinalGrade, updateFinalGrade } from '@/services/escola-lms/grades';
 import { useTeacherSubject } from '../../context';
+import StudentCourseGrades from './StudentCourseGrades';
 import {
   useFinalGrades,
   useGradeTerms,
+  useStudentCourseGrades,
   useStudentExams,
   useSubjectGradeScales,
   useTutorGradeScales,
@@ -120,6 +122,7 @@ export const FinalGradesDetails: React.FC<Props> = ({ user_id, group_id }) => {
     group_id,
     user_id,
   );
+  const { courseGrades } = useStudentCourseGrades(user_id, group_id, semester_subject_id);
 
   const [form] = ProForm.useForm<FormData>();
 
@@ -309,6 +312,16 @@ export const FinalGradesDetails: React.FC<Props> = ({ user_id, group_id }) => {
             loading={tutorGradeScales.loading}
             columns={tutorGradeScalesColumns}
           />
+        </Col>
+        <Col span={24}>
+          <Typography.Text style={{ fontSize: '16px', fontWeight: 500 }}>
+            <FormattedMessage
+              id="gradebook.course_grades_title"
+              defaultMessage="Quiz and project grades"
+            />
+          </Typography.Text>
+          <Divider style={{ margin: '12px 0' }} />
+          <StudentCourseGrades data={courseGrades.data} loading={courseGrades.loading} />
         </Col>
         {areStatisticsLoading && <Spin />}
         {isStatisticDataPresent &&

--- a/src/services/escola-lms/gradebook.ts
+++ b/src/services/escola-lms/gradebook.ts
@@ -1,0 +1,45 @@
+import type { AxiosRequestConfig } from '@umijs/max';
+import { request } from 'umi';
+
+import { GRADEBOOK_ENDPOINTS } from '@/consts/gradebook';
+
+/**
+ * AN-8 — Subject gradebook data (quiz/project grades).
+ *
+ * These are thin wrappers over the *assumed* backend endpoints (delivered as
+ * separate tasks). `skipErrorHandler: true` is set so that, while the endpoints
+ * do not yet exist, a 4xx does not trigger the global handler (which redirects
+ * to /404). Consumers handle `!response.success` by showing an empty state.
+ * Once the backend is live this flag can be revisited.
+ */
+
+/** GET per-student, per-course quiz/project grades + pass/fail (FinalGradesDetails). */
+export async function getStudentCourseGrades(
+  params: API.StudentCourseGradesParams,
+  options?: AxiosRequestConfig,
+) {
+  return request<API.DefaultResponse<API.StudentCourseGrades[]>>(
+    GRADEBOOK_ENDPOINTS.studentCourseGrades,
+    {
+      method: 'GET',
+      params,
+      skipErrorHandler: true,
+      /* useCache: true */ useCache: false,
+      ...(options || {}),
+    },
+  );
+}
+
+/** GET group-level gradebook — only flagged quiz/project items (ClassRegister). */
+export async function getGroupGradebook(
+  params: API.GroupGradebookParams,
+  options?: AxiosRequestConfig,
+) {
+  return request<API.DefaultResponse<API.GroupGradebook>>(GRADEBOOK_ENDPOINTS.groupGradebook, {
+    method: 'GET',
+    params,
+    skipErrorHandler: true,
+    /* useCache: true */ useCache: false,
+    ...(options || {}),
+  });
+}

--- a/src/services/escola-lms/typings.d.ts
+++ b/src/services/escola-lms/typings.d.ts
@@ -567,7 +567,13 @@ declare namespace API {
 
   type TopicProject = TopicBase & {
     topicable_type: TopicType.Project;
-    topicable: TopicableBase & { notify_users?: string[] };
+    topicable: TopicableBase & {
+      notify_users?: string[];
+      // AN-8 gradebook: whether this project's grade is counted in the subject gradebook
+      // and the weight it carries there (default 1). See consts/gradebook.ts.
+      add_to_gradebook?: boolean;
+      grade_weight?: number;
+    };
   };
 
   type TopicQuiz = TopicBase & {
@@ -577,6 +583,10 @@ declare namespace API {
       max_attempts?: number;
       max_execution_time?: number;
       min_pass_score?: number;
+      // AN-8 gradebook: whether this quiz's grade is counted in the subject gradebook
+      // and the weight it carries there (default 1). See consts/gradebook.ts.
+      add_to_gradebook?: boolean;
+      grade_weight?: number;
     };
   };
 
@@ -1901,6 +1911,70 @@ declare namespace API {
 
   type UpdateFinalGradeRequest = {
     grade_scale_id: number;
+  };
+
+  /* ── AN-8: Subject gradebook (quiz/project grades) ───────────────────────────
+     All shapes below describe the *assumed* backend contract consumed by the
+     gradebook feature (see consts/gradebook.ts). Adjust to match the real API
+     when the separate backend tasks land. */
+
+  /** A single quiz/project grade for one student within one course. */
+  type StudentCourseGrade = {
+    topic_id: number;
+    topic_title: string;
+    /** short type name, e.g. "GiftQuiz" | "Project" */
+    topicable_type: string;
+    /** the score/points; null when not yet graded */
+    grade: number | string | null;
+    /** pass/fail for this item; null when not applicable/graded */
+    passed: boolean | null;
+    /** whether this item is included in the gradebook (the checkbox state) */
+    add_to_gradebook: boolean;
+    /** weight the grade carries in the gradebook (default 1) */
+    grade_weight: number;
+  };
+
+  /** All quiz/project grades for one student, grouped per course. */
+  type StudentCourseGrades = {
+    course_id: number;
+    course_title: string;
+    grades: StudentCourseGrade[];
+  };
+
+  type StudentCourseGradesParams = {
+    user_id: number;
+    group_id?: number;
+    semester_subject_id?: number;
+  };
+
+  /** One gradebook column (a flagged quiz/project topic) shared by all students. */
+  type GroupGradebookColumn = {
+    topic_id: number;
+    topic_title: string;
+    topicable_type: string;
+    grade_weight: number;
+  };
+
+  type GroupGradebookStudentGrade = {
+    topic_id: number;
+    grade: number | string | null;
+    passed: boolean | null;
+  };
+
+  type GroupGradebookStudent = {
+    user_id: number;
+    grades: GroupGradebookStudentGrade[];
+  };
+
+  /** Group-level gradebook: only flagged (add_to_gradebook) items are present. */
+  type GroupGradebook = {
+    columns: GroupGradebookColumn[];
+    students: GroupGradebookStudent[];
+  };
+
+  type GroupGradebookParams = {
+    group_id: number;
+    semester_subject_id?: number;
   };
 
   type LessonTopicId = number;

--- a/src/services/escola-lms/typings.d.ts
+++ b/src/services/escola-lms/typings.d.ts
@@ -569,9 +569,9 @@ declare namespace API {
     topicable_type: TopicType.Project;
     topicable: TopicableBase & {
       notify_users?: string[];
-      // AN-8 gradebook: whether this project's grade is counted in the subject gradebook
-      // and the weight it carries there (default 1). See consts/gradebook.ts.
-      add_to_gradebook?: boolean;
+      // AN-8 gradebook: whether this project appears in the final grade (delivered via the
+      // Topic content API) and the weight it carries there (placeholder). See consts/gradebook.ts.
+      counts_to_grade?: boolean;
       grade_weight?: number;
     };
   };
@@ -583,9 +583,10 @@ declare namespace API {
       max_attempts?: number;
       max_execution_time?: number;
       min_pass_score?: number;
-      // AN-8 gradebook: whether this quiz's grade is counted in the subject gradebook
-      // and the weight it carries there (default 1). See consts/gradebook.ts.
-      add_to_gradebook?: boolean;
+      // AN-8 gradebook: whether this quiz appears in the final grade (delivered via the Topic
+      // content API and PUT /api/admin/gift-quizes/{id}) and the weight it carries there
+      // (placeholder). See consts/gradebook.ts.
+      counts_to_grade?: boolean;
       grade_weight?: number;
     };
   };
@@ -1914,9 +1915,10 @@ declare namespace API {
   };
 
   /* ── AN-8: Subject gradebook (quiz/project grades) ───────────────────────────
-     All shapes below describe the *assumed* backend contract consumed by the
-     gradebook feature (see consts/gradebook.ts). Adjust to match the real API
-     when the separate backend tasks land. */
+     All shapes below describe the *assumed* backend contract for the gradebook
+     read endpoints (see consts/gradebook.ts), which remain placeholders. Only the
+     `counts_to_grade` write flag has been delivered so far. Adjust these to match
+     the real API when the separate backend tasks land. */
 
   /** A single quiz/project grade for one student within one course. */
   type StudentCourseGrade = {
@@ -1928,8 +1930,8 @@ declare namespace API {
     grade: number | string | null;
     /** pass/fail for this item; null when not applicable/graded */
     passed: boolean | null;
-    /** whether this item is included in the gradebook (the checkbox state) */
-    add_to_gradebook: boolean;
+    /** whether this item is shown in the final grade (the checkbox state) */
+    counts_to_grade: boolean;
     /** weight the grade carries in the gradebook (default 1) */
     grade_weight: number;
   };
@@ -1966,7 +1968,7 @@ declare namespace API {
     grades: GroupGradebookStudentGrade[];
   };
 
-  /** Group-level gradebook: only flagged (add_to_gradebook) items are present. */
+  /** Group-level gradebook: only flagged (counts_to_grade) items are present. */
   type GroupGradebook = {
     columns: GroupGradebookColumn[];
     students: GroupGradebookStudent[];


### PR DESCRIPTION
- Add "add_to_gradebook" switch + conditional "grade_weight" field to the quiz and project topic forms (prefill 1, decimals, > 0); serialize on save and read back on edit
- Show per-course quiz/project grade tables (+ pass/fail) per student in FinalGradesDetails; graceful empty state, one table per course
- Add flagged-only gradebook columns to ClassRegister
- Add documented placeholder gradebook API service + types, with field names / endpoints centralized in consts/gradebook.ts (backend TBD)
- Add en-US / pl-PL translations