### PR TITLE
feat(AN-28): add quiz reports export button to course reports tab

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -325,6 +325,7 @@ export default {
   upload: 'Add file',
   preview: 'Preview',
   export: 'Export',
+  export_failed: 'Export failed',
   able_to_preview: 'Able to preview',
   loading_content: 'Loading content...',
   preview_content: 'Preview content',

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -309,6 +309,7 @@ export default {
   upload: 'Dodaj plik',
   preview: 'Podgląd',
   export: 'Eksport',
+  export_failed: 'Eksport nie powiódł się',
   able_to_preview: 'Możliwość podglądu',
   loading_content: 'Ładowanie treści...',
   preview_content: 'Podgląd treści',

--- a/src/pages/Courses/components/CourseQuizReports.tsx
+++ b/src/pages/Courses/components/CourseQuizReports.tsx
@@ -1,5 +1,5 @@
 import { FileSearchOutlined } from '@ant-design/icons';
-import type { ProTableProps } from '@ant-design/pro-components';
+import type { ProFormInstance, ProTableProps } from '@ant-design/pro-components';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
 import ProTable from '@ant-design/pro-table';
 import { Button, Tag, Tooltip } from 'antd';
@@ -12,6 +12,7 @@ import { DATETIME_FORMAT } from '@/consts/dates';
 import { getQuizAttempts } from '@/services/escola-lms/gift_quiz';
 import { createTableOrderObject } from '@/utils/utils';
 
+import CourseQuizReportsExportButton from './CourseQuizReportsExportButton';
 import CourseQuizSelect from './CourseQuizSelect';
 
 type ProTableRequest = NonNullable<
@@ -20,6 +21,7 @@ type ProTableRequest = NonNullable<
 
 export const CourseQuizReports: React.FC<{ courseId: number }> = ({ courseId }) => {
   const actionRef = useRef<ActionType>();
+  const formRef = useRef<ProFormInstance>();
   const intl = useIntl();
 
   const columns: ProColumns<API.QuizAttempt>[] = [
@@ -166,9 +168,17 @@ export const CourseQuizReports: React.FC<{ courseId: number }> = ({ courseId }) 
         layout: 'vertical',
       }}
       actionRef={actionRef}
+      formRef={formRef}
       rowKey="id"
       request={onRequest}
       columns={columns}
+      toolBarRender={() => [
+        <CourseQuizReportsExportButton
+          key="export"
+          courseId={courseId}
+          topicGiftQuizId={formRef.current?.getFieldValue('topic_gift_quiz_id')}
+        />,
+      ]}
     />
   );
 };

--- a/src/pages/Courses/components/CourseQuizReports.tsx
+++ b/src/pages/Courses/components/CourseQuizReports.tsx
@@ -173,11 +173,7 @@ export const CourseQuizReports: React.FC<{ courseId: number }> = ({ courseId }) 
       request={onRequest}
       columns={columns}
       toolBarRender={() => [
-        <CourseQuizReportsExportButton
-          key="export"
-          courseId={courseId}
-          topicGiftQuizId={formRef.current?.getFieldValue('topic_gift_quiz_id')}
-        />,
+        <CourseQuizReportsExportButton key="export" courseId={courseId} formRef={formRef} />,
       ]}
     />
   );

--- a/src/pages/Courses/components/CourseQuizReportsExportButton.tsx
+++ b/src/pages/Courses/components/CourseQuizReportsExportButton.tsx
@@ -1,4 +1,5 @@
 import { ExportOutlined } from '@ant-design/icons';
+import type { ProFormInstance } from '@ant-design/pro-components';
 import { Button, message } from 'antd';
 import React, { useCallback, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -7,10 +8,10 @@ import { exportQuizAttempts } from '@/services/escola-lms/gift_quiz';
 
 interface Props {
   courseId: number;
-  topicGiftQuizId?: number;
+  formRef: React.MutableRefObject<ProFormInstance | undefined>;
 }
 
-export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, topicGiftQuizId }) => {
+export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, formRef }) => {
   const [loading, setLoading] = useState(false);
   const intl = useIntl();
 
@@ -19,9 +20,12 @@ export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, topic
     try {
       const response = await exportQuizAttempts({
         course_id: courseId,
-        topic_gift_quiz_id: topicGiftQuizId,
+        // Resolved at click time so the export always matches the current filter selection,
+        // regardless of when the ProTable last re-rendered.
+        topic_gift_quiz_id: formRef.current?.getFieldValue('topic_gift_quiz_id'),
       });
 
+      // A resolved blob request always yields a Blob; errors reject into the catch below.
       if (response instanceof Blob) {
         const downloadLink = document.createElement('a');
         downloadLink.href = window.URL.createObjectURL(response);
@@ -30,16 +34,15 @@ export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, topic
         downloadLink.click();
         document.body.removeChild(downloadLink);
         window.URL.revokeObjectURL(downloadLink.href);
-      } else {
-        message.error(intl.formatMessage({ id: 'export_failed', defaultMessage: 'Export failed' }));
       }
     } catch (error) {
+      // The global errorHandler can't surface blob error bodies, so show an explicit message here.
       console.error(error);
       message.error(intl.formatMessage({ id: 'export_failed', defaultMessage: 'Export failed' }));
     } finally {
       setLoading(false);
     }
-  }, [courseId, topicGiftQuizId, intl]);
+  }, [courseId, formRef, intl]);
 
   return (
     <Button type="primary" loading={loading} onClick={onClick}>

--- a/src/pages/Courses/components/CourseQuizReportsExportButton.tsx
+++ b/src/pages/Courses/components/CourseQuizReportsExportButton.tsx
@@ -1,0 +1,51 @@
+import { ExportOutlined } from '@ant-design/icons';
+import { Button, message } from 'antd';
+import React, { useCallback, useState } from 'react';
+import { FormattedMessage, useIntl } from 'umi';
+
+import { exportQuizAttempts } from '@/services/escola-lms/gift_quiz';
+
+interface Props {
+  courseId: number;
+  topicGiftQuizId?: number;
+}
+
+export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, topicGiftQuizId }) => {
+  const [loading, setLoading] = useState(false);
+  const intl = useIntl();
+
+  const onClick = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await exportQuizAttempts({
+        course_id: courseId,
+        topic_gift_quiz_id: topicGiftQuizId,
+      });
+
+      if (response instanceof Blob) {
+        const downloadLink = document.createElement('a');
+        downloadLink.href = window.URL.createObjectURL(response);
+        downloadLink.download = `quiz_results_${courseId}.xlsx`;
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+        window.URL.revokeObjectURL(downloadLink.href);
+      } else {
+        message.error(intl.formatMessage({ id: 'export_failed', defaultMessage: 'Export failed' }));
+      }
+    } catch (error) {
+      console.error(error);
+      message.error(intl.formatMessage({ id: 'export_failed', defaultMessage: 'Export failed' }));
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId, topicGiftQuizId, intl]);
+
+  return (
+    <Button type="primary" loading={loading} onClick={onClick}>
+      <ExportOutlined /> <FormattedMessage id="export" defaultMessage="Export" />
+    </Button>
+  );
+};
+
+export default CourseQuizReportsExportButton;

--- a/src/pages/Courses/components/CourseQuizReportsExportButton/index.tsx
+++ b/src/pages/Courses/components/CourseQuizReportsExportButton/index.tsx
@@ -1,0 +1,24 @@
+import { ExportOutlined } from '@ant-design/icons';
+import type { ProFormInstance } from '@ant-design/pro-components';
+import { Button } from 'antd';
+import React from 'react';
+import { FormattedMessage } from 'umi';
+
+import { useExportQuizReports } from './useExportQuizReports';
+
+interface Props {
+  courseId: number;
+  formRef: React.MutableRefObject<ProFormInstance | undefined>;
+}
+
+export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, formRef }) => {
+  const { loading, exportQuizReports } = useExportQuizReports(courseId, formRef);
+
+  return (
+    <Button type="primary" loading={loading} onClick={exportQuizReports}>
+      <ExportOutlined /> <FormattedMessage id="export" defaultMessage="Export" />
+    </Button>
+  );
+};
+
+export default CourseQuizReportsExportButton;

--- a/src/pages/Courses/components/CourseQuizReportsExportButton/useExportQuizReports.ts
+++ b/src/pages/Courses/components/CourseQuizReportsExportButton/useExportQuizReports.ts
@@ -25,13 +25,16 @@ export const useExportQuizReports = (
 
       // A resolved blob request always yields a Blob; errors reject into the catch below.
       if (response instanceof Blob) {
+        const objectUrl = window.URL.createObjectURL(response);
         const downloadLink = document.createElement('a');
-        downloadLink.href = window.URL.createObjectURL(response);
+        downloadLink.href = objectUrl;
         downloadLink.download = `quiz_results_${courseId}.xlsx`;
         document.body.appendChild(downloadLink);
         downloadLink.click();
         document.body.removeChild(downloadLink);
-        window.URL.revokeObjectURL(downloadLink.href);
+        // Defer revocation: click() starts the download asynchronously, so revoking the URL
+        // synchronously can cancel the download before the browser reads the blob.
+        setTimeout(() => window.URL.revokeObjectURL(objectUrl), 0);
       }
     } catch (error) {
       // The global errorHandler can't surface blob error bodies, so show an explicit message here.

--- a/src/pages/Courses/components/CourseQuizReportsExportButton/useExportQuizReports.ts
+++ b/src/pages/Courses/components/CourseQuizReportsExportButton/useExportQuizReports.ts
@@ -1,21 +1,19 @@
-import { ExportOutlined } from '@ant-design/icons';
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { Button, message } from 'antd';
-import React, { useCallback, useState } from 'react';
-import { FormattedMessage, useIntl } from 'umi';
+import { message } from 'antd';
+import type { MutableRefObject } from 'react';
+import { useCallback, useState } from 'react';
+import { useIntl } from 'umi';
 
 import { exportQuizAttempts } from '@/services/escola-lms/gift_quiz';
 
-interface Props {
-  courseId: number;
-  formRef: React.MutableRefObject<ProFormInstance | undefined>;
-}
-
-export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, formRef }) => {
+export const useExportQuizReports = (
+  courseId: number,
+  formRef: MutableRefObject<ProFormInstance | undefined>,
+) => {
   const [loading, setLoading] = useState(false);
   const intl = useIntl();
 
-  const onClick = useCallback(async () => {
+  const exportQuizReports = useCallback(async () => {
     setLoading(true);
     try {
       const response = await exportQuizAttempts({
@@ -44,11 +42,7 @@ export const CourseQuizReportsExportButton: React.FC<Props> = ({ courseId, formR
     }
   }, [courseId, formRef, intl]);
 
-  return (
-    <Button type="primary" loading={loading} onClick={onClick}>
-      <ExportOutlined /> <FormattedMessage id="export" defaultMessage="Export" />
-    </Button>
-  );
+  return { loading, exportQuizReports };
 };
 
-export default CourseQuizReportsExportButton;
+export default useExportQuizReports;

--- a/src/services/escola-lms/gift_quiz.ts
+++ b/src/services/escola-lms/gift_quiz.ts
@@ -93,6 +93,19 @@ export async function getCourseGiftQuizzes(
   });
 }
 
+/** GET /api/admin/quiz-attempts/export */
+export async function exportQuizAttempts(
+  params: API.ExportQuizAttemptsParams,
+  options?: AxiosRequestConfig,
+) {
+  return request<Blob | API.DefaultResponseError>('/api/admin/quiz-attempts/export', {
+    method: 'GET',
+    responseType: 'blob',
+    params,
+    ...(options || {}),
+  });
+}
+
 /** GET /api/admin/gift-quizes/{id} */
 export async function getGiftQuiz(id: string | number, options?: AxiosRequestConfig) {
   return request<API.DefaultResponse<API.GiftQuiz>>(`/api/admin/gift-quizes/${id}`, {

--- a/src/services/escola-lms/typings.d.ts
+++ b/src/services/escola-lms/typings.d.ts
@@ -1588,6 +1588,11 @@ declare namespace API {
     course_id: number;
   };
 
+  type ExportQuizAttemptsParams = {
+    course_id: number;
+    topic_gift_quiz_id?: number;
+  };
+
   type GiftQuiz = {
     id: number;
     value: string;


### PR DESCRIPTION
 Adds an XLSX export button to the course Quiz Reports tab (introduced in AN-18). File generation happens entirely backend-side — the FE only sends the request based on the tab's current filter state and triggers the download.                                                                                   
                  
## Behavior:                                                                                                                                                                                                                                                                                                           
  - **No quiz selected** → request sent without the quiz filter (`?course_id=X`); backend exports all course quizzes, one sheet each.                                                                                                                                                                                 
  - **One quiz selected** → request includes `topic_gift_quiz_id` (`?course_id=X&topic_gift_quiz_id=Y`); backend exports that single quiz.                                                                                                                                                                            
  - Export covers all attempts of all students.                                                                                                                                                                                                                                                                       
  - Request failures surface an antd error notification (no silent failure).                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                      
  ## Changes                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                      
  - `services/escola-lms/gift_quiz.ts`: new `exportQuizAttempts()` service (`GET /api/admin/quiz-attempts/export`, blob response).                                                                                                                                                                                    
  - `services/escola-lms/typings.d.ts`: new `ExportQuizAttemptsParams` type.                                                                                                                                                                                                                                          
  - New `CourseQuizReportsExportButton` component (loading state, blob download, error handling).                                                                                                                                                                                                                     
  - `CourseQuizReports`: added `formRef` + `toolBarRender` to place the export button in the table toolbar, reading the live quiz filter.                                                                                                                                                                             
  - i18n: added `export_failed` (en/pl); reused existing `export` label.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                      
  ## Backend dependency                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                      
  Relies on the AN-28 backend endpoint `GET /api/admin/quiz-attempts/export?course_id=X&topic_gift_quiz_id=Y` (list authorization). The export intentionally sends only `course_id` (+ optional quiz), not the date-range filter, per the agreed contract.                                                            
                                                                                                                                                                                                                                                                                                                      
  ## Testing                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                      
  - `yarn tsc:noemit` ✅                                                                                                                                                                                                                                                                                               
  - `yarn lint:js` ✅                                                                                                                                                                                                                                                                                                  
  - Prettier ✅              