### PR TITLE
feat(AN-26): add randomize question order toggle to GIFT quiz topic

### DIFF
--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
@@ -184,6 +184,13 @@ export const Topic: React.FC = () => {
       values.value = 'theProject';
     }
 
+    // GIFT quiz randomize toggle: send as 1/0 (Laravel boolean-safe), and only when the
+    // user actually toggled it so an untouched edit doesn't overwrite the stored value.
+    const randomizeOrder = (topics as { randomize_order?: boolean }).randomize_order;
+    if (typeof randomizeOrder === 'boolean') {
+      (values as Record<string, unknown>).randomize_order = randomizeOrder ? 1 : 0;
+    }
+
     const formData = getFormData(values);
 
     handleSave(formData);

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/index.tsx
@@ -186,9 +186,8 @@ export const Topic: React.FC = () => {
 
     // GIFT quiz randomize toggle: send as 1/0 (Laravel boolean-safe), and only when the
     // user actually toggled it so an untouched edit doesn't overwrite the stored value.
-    const randomizeOrder = (topics as { randomize_order?: boolean }).randomize_order;
-    if (typeof randomizeOrder === 'boolean') {
-      (values as Record<string, unknown>).randomize_order = randomizeOrder ? 1 : 0;
+    if (typeof topics.randomize_order === 'boolean') {
+      values.randomize_order = topics.randomize_order ? 1 : 0;
     }
 
     const formData = getFormData(values);

--- a/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
+++ b/src/components/ProgramForm/ThreeColProgram/TopicForm/media/giftquiz.tsx
@@ -1,5 +1,5 @@
 import { Table } from '@/components/GiftQuizQuestions/table';
-import ProForm, { ProFormDigit, ProFormGroup } from '@ant-design/pro-form';
+import ProForm, { ProFormDigit, ProFormGroup, ProFormSwitch } from '@ant-design/pro-form';
 import { Divider } from 'antd';
 import Typography from 'antd/lib/typography/Typography';
 import React, { Fragment } from 'react';
@@ -7,7 +7,10 @@ import { FormattedMessage, useIntl } from 'umi';
 
 export const GiftQuiz: React.FC<{
   topicable: API.TopicQuiz['topicable'];
-  onChange: (key: 'max_attempts' | 'max_execution_time', value: number | null) => void;
+  onChange: (
+    key: 'max_attempts' | 'max_execution_time' | 'min_pass_score' | 'randomize_order',
+    value: number | boolean | null,
+  ) => void;
   onAdded?: () => void;
   onRemoved?: () => void;
   onEdited?: () => void;
@@ -21,9 +24,14 @@ export const GiftQuiz: React.FC<{
           max_attempts: topicable ? topicable.max_attempts : undefined,
           max_execution_time: topicable ? topicable.max_execution_time : undefined,
           min_pass_score: topicable ? topicable.min_pass_score : undefined,
+          randomize_order: topicable ? topicable.randomize_order ?? false : false,
         }}
         onValuesChange={(values) => {
-          const key = Object.keys(values)[0] as 'max_attempts' | 'max_execution_time';
+          const key = Object.keys(values)[0] as
+            | 'max_attempts'
+            | 'max_execution_time'
+            | 'min_pass_score'
+            | 'randomize_order';
           if (key) {
             onChange(key, values[key]);
           }
@@ -58,6 +66,11 @@ export const GiftQuiz: React.FC<{
               id: 'min_pass_score',
               defaultMessage: 'min_pass_score',
             })}
+          />
+          <ProFormSwitch
+            name="randomize_order"
+            label={<FormattedMessage id="randomize_questions_order" />}
+            tooltip={<FormattedMessage id="randomize_questions_order_tooltip" />}
           />
         </ProFormGroup>
       </ProForm>

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -683,6 +683,9 @@ export default {
   max_execution_time_tooltip: 'The maximum duration of the exam in minutes.',
   min_pass_score: 'Min pass score',
   min_pass_score_tooltip: 'The minimum score a student must achieve to pass (in %).',
+  randomize_questions_order: 'Randomize question order',
+  randomize_questions_order_tooltip:
+    'When enabled, each attempt shows the questions in a shuffled order.',
   status_consultation_tooltip: 'Status',
   tutor_consultation_tooltip: 'Tutor',
   proposed_terms_tooltip: 'Proposed terms',

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -649,6 +649,9 @@ export default {
   max_execution_time_tooltip: 'Maksymalny czas trwania egzaminu wyrażony w minutach.',
   min_pass_score: 'Minimalny pozytywny wynik',
   min_pass_score_tooltip: 'Minimalny wynik który musi uzyskać student aby zdać (wyrażony w %).',
+  randomize_questions_order: 'Losowa kolejność pytań',
+  randomize_questions_order_tooltip:
+    'Gdy włączone, każde podejście pokazuje pytania w losowej kolejności.',
   status_consultation_tooltip: 'Status',
   tutor_consultation_tooltip: 'Trener',
   proposed_terms_tooltip: 'Proponowane terminy',

--- a/src/services/escola-lms/typings.d.ts
+++ b/src/services/escola-lms/typings.d.ts
@@ -522,6 +522,9 @@ declare namespace API {
     active?: boolean;
     preview?: boolean;
     can_skip?: boolean;
+    // GIFT quiz: nested in `topicable` on read, flattened to the top level for the PUT
+    // body (like `value`). Boolean in state, sent as 1/0 on the wire.
+    randomize_order?: boolean | number;
     json?: object &
       ?{
         ffmpeg:

--- a/src/services/escola-lms/typings.d.ts
+++ b/src/services/escola-lms/typings.d.ts
@@ -577,6 +577,7 @@ declare namespace API {
       max_attempts?: number;
       max_execution_time?: number;
       min_pass_score?: number;
+      randomize_order?: boolean;
     };
   };
 


### PR DESCRIPTION
Add a ProFormSwitch to the GIFT quiz topic create/edit form that sets the                                                                                                                                                                                                                                           
  `randomize_order` flag. Defaults to off, reads back from topicable on edit,                                                                                                                                                                                                                                         
  and is sent to the topic-update endpoint as 1/0 (only when toggled, so an                                                                                                                                                                                                                                           
  untouched edit won't overwrite the stored value). Adds EN/PL labels and the                                                                                                                                                                                                                                         
  `randomize_order` field on TopicQuiz['topicable'].