### PR TITLE
feat(AN-21): persist selected semester in URL on Teacher Subjects page

### DIFF
--- a/src/components/SemesterSelect/index.tsx
+++ b/src/components/SemesterSelect/index.tsx
@@ -60,6 +60,18 @@ export const SemesterSelect: React.FC<{
     [fetch],
   );
 
+  // When a value is provided up-front (e.g. filter restored from the URL), load the
+  // options on mount so the selection renders its semester name instead of the raw id.
+  useEffect(() => {
+    const hasValue = Array.isArray(value)
+      ? value.length > 0
+      : value !== undefined && value !== null;
+    if (hasValue) {
+      fetch();
+    }
+    // Run once on mount; only the initial restored value needs resolving here.
+  }, []);
+
   return (
     <Select
       onSelect={onSelect}

--- a/src/pages/TeacherSubjects/helpers.test.ts
+++ b/src/pages/TeacherSubjects/helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { buildSemesterSearch, parseSemesterId } from './helpers';
+
+describe('parseSemesterId', () => {
+  it('reads a numeric semester id from the query string', () => {
+    expect(parseSemesterId('?semester_id=5')).toBe(5);
+  });
+
+  it('returns undefined when the param is absent', () => {
+    expect(parseSemesterId('')).toBeUndefined();
+    expect(parseSemesterId('?other=1')).toBeUndefined();
+  });
+
+  it('returns undefined for a non-numeric value', () => {
+    expect(parseSemesterId('?semester_id=abc')).toBeUndefined();
+  });
+});
+
+describe('buildSemesterSearch', () => {
+  it('sets the semester id when one is selected', () => {
+    expect(buildSemesterSearch('', 5)).toBe('semester_id=5');
+  });
+
+  it('removes the semester id when cleared', () => {
+    expect(buildSemesterSearch('?semester_id=5', undefined)).toBe('');
+  });
+
+  it('preserves unrelated params', () => {
+    expect(buildSemesterSearch('?page=2', 5)).toBe('page=2&semester_id=5');
+    expect(buildSemesterSearch('?page=2&semester_id=5', undefined)).toBe('page=2');
+  });
+});

--- a/src/pages/TeacherSubjects/helpers.ts
+++ b/src/pages/TeacherSubjects/helpers.ts
@@ -1,0 +1,34 @@
+// Pure URL helpers for the Teacher Subjects list. Kept side-effect free (no umi
+// `history`) so the semester <-> query-string mapping can be unit tested without
+// pulling in the router / component graph. The component performs the actual
+// `history.replace` using the string these helpers produce.
+
+// Query-string key under which the selected semester is persisted, so refresh,
+// browser-back, and shared links all reconstruct the same filter.
+export const SEMESTER_ID_PARAM = 'semester_id';
+
+// Reads the selected semester id from a location search string. Returns a number
+// (so it matches the numeric <Select.Option> values) or undefined when absent or
+// not a valid number, in which case no semester filter is applied.
+export const parseSemesterId = (search: string): number | undefined => {
+  const raw = new URLSearchParams(search).get(SEMESTER_ID_PARAM);
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+// Builds the next location search string with the semester filter applied: sets
+// the param when a semester is selected, removes it when cleared. Other existing
+// params in `currentSearch` are preserved. Returns the query string without a
+// leading `?`.
+export const buildSemesterSearch = (currentSearch: string, semesterId?: number): string => {
+  const params = new URLSearchParams(currentSearch);
+  if (semesterId) {
+    params.set(SEMESTER_ID_PARAM, String(semesterId));
+  } else {
+    params.delete(SEMESTER_ID_PARAM);
+  }
+  return params.toString();
+};

--- a/src/pages/TeacherSubjects/helpers.ts
+++ b/src/pages/TeacherSubjects/helpers.ts
@@ -1,15 +1,10 @@
-// Pure URL helpers for the Teacher Subjects list. Kept side-effect free (no umi
-// `history`) so the semester <-> query-string mapping can be unit tested without
-// pulling in the router / component graph. The component performs the actual
-// `history.replace` using the string these helpers produce.
-
-// Query-string key under which the selected semester is persisted, so refresh,
-// browser-back, and shared links all reconstruct the same filter.
+// URL <-> semester-filter mapping for the Teacher Subjects list. Side-effect free
+// (no umi `history`) so it's unit-testable in isolation — see helpers.test.ts.
+// The component performs the actual history.replace with the string these produce.
 export const SEMESTER_ID_PARAM = 'semester_id';
 
-// Reads the selected semester id from a location search string. Returns a number
-// (so it matches the numeric <Select.Option> values) or undefined when absent or
-// not a valid number, in which case no semester filter is applied.
+// Returns a number (so it matches the numeric <Select.Option> values)
+// or undefined when absent or not a valid number, in which case no semester filter is applied.
 export const parseSemesterId = (search: string): number | undefined => {
   const raw = new URLSearchParams(search).get(SEMESTER_ID_PARAM);
   if (!raw) {

--- a/src/pages/TeacherSubjects/index.tsx
+++ b/src/pages/TeacherSubjects/index.tsx
@@ -5,14 +5,16 @@ import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
 import ProTable from '@ant-design/pro-table';
 import { Button, Tooltip } from 'antd';
-import React, { useRef } from 'react';
-import { FormattedMessage, Link, useIntl } from 'umi';
+import React, { useRef, useState } from 'react';
+import { FormattedMessage, Link, history, useIntl, useLocation } from 'umi';
 import { TEACHER_SUBJECTS_PAGE_SIZE } from './components/consts';
+import { buildSemesterSearch, parseSemesterId } from './helpers';
 
 export const TableColumns: ProColumns<API.Subjects>[] = [
   {
     hideInSearch: false,
     hideInTable: true,
+    colSize: 2,
     title: <FormattedMessage id="semester" defaultMessage="semester" />,
     dataIndex: 'semester_id',
     renderFormItem: (item, { type, defaultRender, ...rest }, form) => {
@@ -66,6 +68,10 @@ export const TableColumns: ProColumns<API.Subjects>[] = [
 const TableList: React.FC = () => {
   const actionRef = useRef<ActionType>();
   const intl = useIntl();
+  const location = useLocation();
+  // Read the selected semester from the URL once so the filter is restored on
+  // browser-back, refresh, or when opening a link that already carries the param.
+  const [initialSemesterId] = useState(() => parseSemesterId(location.search));
 
   return (
     <PageContainer>
@@ -79,8 +85,15 @@ const TableList: React.FC = () => {
         search={{
           layout: 'vertical',
         }}
+        form={{ initialValues: { semester_id: initialSemesterId } }}
         pagination={{ defaultPageSize: TEACHER_SUBJECTS_PAGE_SIZE }}
         request={({ pageSize, current, semester_id }) => {
+          // Mirror the applied filter into the URL query so it survives navigation.
+          history.replace({
+            pathname: history.location.pathname,
+            search: buildSemesterSearch(history.location.search, semester_id),
+          });
+
           return semesterSubjects({ per_page: pageSize, page: current, semester_id }).then(
             (response) => {
               if (response.success) {
@@ -90,7 +103,7 @@ const TableList: React.FC = () => {
                   success: true,
                 };
               }
-              return [];
+              return { data: [], total: 0, success: false };
             },
           );
         }}


### PR DESCRIPTION
Store the semester filter in the URL query string so it survives navigation,                                                                                                                                                                                                                                        
  refresh, and shared links, instead of living only in ProTable's internal                                                                                                                                                                                                                                            
  search-form state (lost when entering a subject's details and returning).                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                      
  - Restore the filter from the hash query on mount and feed it to the search                                                                                                                                                                                                                                         
    form via `form.initialValues`; mirror the applied filter back into the URL                                                                                                                                                                                                                                        
    from `request` with `history.replace`.                                                                                                                                                                                                                                                                            
  - Extract pure URL helpers (`parseSemesterId`, `buildSemesterSearch`) into                                                                                                                                                                                                                                          
    TeacherSubjects/helpers.ts, with co-located unit tests.                                                                                                                                                                                                                                                           
  - Load SemesterSelect options on mount when a value is preset, so a                                                                                                                                                                                                                                                 
    URL-restored selection renders its name instead of the raw id.                                                                                                                                                                                                                                                    
  - Widen the semester search cell (colSize) so the full selection is visible.                                                                                                                                                                                                                                        
  - Return a well-formed empty result on request failure instead of a bare [].