### PR TITLE
feat(AN-34): add weighted average column to class register

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@sentry/cli": "^2.28.0",
     "@sentry/react": "^7.99.0",
     "@sentry/tracing": "^7.99.0",
-    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/jest-dom": "6.9.1",
     "@umijs/route-utils": "^2.2.2",
     "@webscopeio/react-textarea-autocomplete": "^4.9.2",
     "antd": "5.15.3",

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -790,6 +790,7 @@ export default {
   'TeacherSubjects.FinalGrades.FinalGrade': 'Final grade',
   'TeacherSubjects.FinalGrades.ProposedGrade':
     'Proposed grade (only includes weighted grades): {grade}',
+  'TeacherSubjects.FinalGrades.WeightedAverage': 'Weighted average: {average}',
   'TeacherSubjects.FinalGrades.IssueAssessment': 'Issue an assessment',
   date: 'Date',
   issued_at: 'Issued at',
@@ -829,6 +830,7 @@ export default {
   classRegisterTitleWithGroupName: 'Class register of group {groupName}',
   gradesScalesMissing: 'There is no grading scale for the selected teacher',
   proposed_grade: 'Proposed grade',
+  weighted_average: 'Weighted average',
   groupDataMissing: 'Missing data for group {group_name}',
   file_downloaded: 'File downloaded',
   file_downloaded_error: "Can't download file",

--- a/src/locales/pl-PL.ts
+++ b/src/locales/pl-PL.ts
@@ -757,6 +757,7 @@ export default {
   'TeacherSubjects.FinalGrades.FinalGrade': 'Ocena końcowa',
   'TeacherSubjects.FinalGrades.ProposedGrade':
     'Proponowana ocena (uwzględnia tylko oceny z wagą): {grade} ',
+  'TeacherSubjects.FinalGrades.WeightedAverage': 'Średnia ważona: {average}',
   'TeacherSubjects.FinalGrades.IssueAssessment': 'Wystaw ocenę końcową',
   date: 'Data',
   issued_at: 'Wystawiono',
@@ -796,6 +797,7 @@ export default {
   classRegisterTitleWithGroupName: 'Dziennik grupy {groupName}',
   gradesScalesMissing: 'Brak skali ocen dla wybranego dydaktyka',
   proposed_grade: 'Proponowana ocena (uwzględnia tylko oceny z wagą)',
+  weighted_average: 'Średnia ważona',
   groupDataMissing: 'Brak danych dla grupy {group_name}',
   file_downloaded: 'Pobrano plik',
   file_downloaded_error: 'Nie udało się pobrać pliku',

--- a/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
+++ b/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
@@ -27,6 +27,7 @@ import {
   getProposedGrade,
   getScalesBySubjectScaleFormId,
   getStudentExamsFromExams,
+  getWeightedAverage,
 } from '../FinalGradesDetails/utils';
 import { TEACHER_SUBJECTS_PAGE_SIZE } from '../consts';
 import { isFrozenAttendance } from './helpers';
@@ -293,6 +294,13 @@ export const ClassRegister: React.FC = () => {
               examsCols,
               finalGradeCols,
               {
+                title: <FormattedMessage id="weighted_average" />,
+                hideInSearch: true,
+                dataIndex: 'weighted_average',
+                align: 'center',
+                width: 100,
+              },
+              {
                 title: <FormattedMessage id="proposed_grade" />,
                 hideInSearch: true,
                 dataIndex: 'proposed_grade',
@@ -329,6 +337,8 @@ export const ClassRegister: React.FC = () => {
 
                   const proposed_grade = getProposedGrade(studentExams, tutorScales);
 
+                  const weighted_average = getWeightedAverage(studentExams);
+
                   const studentExamResults = getStudentExamResults(studentExams);
 
                   const finalGrades = getFinalGrades(studentFinalGrades);
@@ -341,6 +351,7 @@ export const ClassRegister: React.FC = () => {
                       ...studentAttendances,
                       ...studentExamResults,
                       ...finalGrades,
+                      weighted_average,
                       proposed_grade,
                       final_grades: studentFinalGrades,
                     },

--- a/src/pages/TeacherSubjects/components/ClassRegister/types.ts
+++ b/src/pages/TeacherSubjects/components/ClassRegister/types.ts
@@ -1,6 +1,7 @@
 export type ClassRegisterTableItemBase = {
   id: number;
   full_name: string;
+  weighted_average: string;
   proposed_grade: string;
   final_grades?: API.FinalGradeItem;
 };

--- a/src/pages/TeacherSubjects/components/ClassRegister/utils.tsx
+++ b/src/pages/TeacherSubjects/components/ClassRegister/utils.tsx
@@ -168,6 +168,7 @@ export const getAttendanceSummaryCells = ({
     index += finalGradeCount;
   }
 
+  cells.push(<Table.Summary.Cell key="weighted_average" index={index++} />);
   cells.push(<Table.Summary.Cell key="proposed_grade" index={index++} />);
   cells.push(<Table.Summary.Cell key="option" index={index++} />);
 

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/index.tsx
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/index.tsx
@@ -21,7 +21,7 @@ import {
   useUserCoursesStats,
 } from './hooks';
 import type { StudentExam } from './types';
-import { getProposedGrade } from './utils';
+import { getProposedGrade, getWeightedAverage } from './utils';
 
 interface Props {
   user_id: number;
@@ -140,6 +140,11 @@ export const FinalGradesDetails: React.FC<Props> = ({ user_id, group_id }) => {
   const proposedGrade = useMemo(
     () => getProposedGrade(studentExams.data ?? [], tutorGradeScales.data ?? []),
     [studentExams.data, tutorGradeScales.data],
+  );
+
+  const weightedAverage = useMemo(
+    () => getWeightedAverage(studentExams.data ?? []),
+    [studentExams.data],
   );
 
   const onFinalGradeSubmit = useCallback(
@@ -350,6 +355,12 @@ export const FinalGradesDetails: React.FC<Props> = ({ user_id, group_id }) => {
             options={gradesSelectOptions}
             fieldProps={{ loading: finalGrades.loading || subjectGradeScales.loading }}
           />
+          <ProForm.Item>
+            <FormattedMessage
+              id="TeacherSubjects.FinalGrades.WeightedAverage"
+              values={{ average: weightedAverage }}
+            />
+          </ProForm.Item>
           <ProForm.Item>
             <FormattedMessage
               id="TeacherSubjects.FinalGrades.ProposedGrade"

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/utils.test.ts
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { StudentExam } from './types';
+import { getProposedGrade, getWeightedAverage, getWeightedAverageValue } from './utils';
+
+// Minimal StudentExam: getWeightedAverage only reads `weight` and `result.result`.
+const exam = (weight: number | undefined, result: number | string | null): StudentExam =>
+  ({ weight, result: { result } } as StudentExam);
+
+describe('getWeightedAverageValue', () => {
+  it('computes the weighted average over weighted, numeric grades', () => {
+    // (5*2 + 2*1) / (2 + 1) = 4
+    expect(getWeightedAverageValue([exam(2, 5), exam(1, 2)])).toBe(4);
+  });
+
+  it('returns null when there is no grade with a weight', () => {
+    expect(getWeightedAverageValue([])).toBeNull();
+    expect(getWeightedAverageValue([exam(undefined, 5), exam(0, 4)])).toBeNull();
+  });
+});
+
+describe('getWeightedAverage', () => {
+  it('uses only grades that have a weight; grades without weight are ignored', () => {
+    // second exam has no weight -> only the first (8 / 2 = 4) counts
+    expect(getWeightedAverage([exam(2, 4), exam(undefined, 5)])).toBe('4.00');
+  });
+
+  it('ignores grades whose result is not numeric', () => {
+    // null and string results are skipped -> only 3 (weight 1) counts
+    expect(getWeightedAverage([exam(2, null), exam(2, 'abc'), exam(1, 3)])).toBe('3.00');
+  });
+
+  it('rounds mathematically to 2 decimal places', () => {
+    // 10 / 3 = 3.3333... -> 3.33
+    expect(getWeightedAverage([exam(1, 3), exam(1, 4), exam(1, 3)])).toBe('3.33');
+    // 14 / 3 = 4.6666... -> 4.67
+    expect(getWeightedAverage([exam(1, 4), exam(2, 5)])).toBe('4.67');
+  });
+
+  it('rounds half up at float boundaries (1.005 -> "1.01", not "1.00")', () => {
+    // 201 / 200 = 1.005 -> "1.01" (plain Math.round(1.005*100) would give "1.00")
+    expect(getWeightedAverage([exam(200, 1.005)])).toBe('1.01');
+    // 203 / 200 = 1.015 -> "1.02"
+    expect(getWeightedAverage([exam(200, 1.015)])).toBe('1.02');
+  });
+
+  it('returns the empty state for a non-finite result instead of "NaN"', () => {
+    // typeof NaN === 'number' so it passes the weight/number filter; the finite
+    // guard must still keep it out of the displayed value.
+    expect(getWeightedAverage([exam(1, NaN)])).toBe('-');
+  });
+
+  it('always shows two decimal places', () => {
+    // 14 / 4 = 3.5 -> "3.50", not "3.5"
+    expect(getWeightedAverage([exam(1, 5), exam(3, 3)])).toBe('3.50');
+  });
+
+  it('shows an empty state ("-") instead of a divide-by-zero value when no grade has a weight', () => {
+    expect(getWeightedAverage([])).toBe('-');
+    expect(getWeightedAverage([exam(undefined, 5)])).toBe('-');
+  });
+});
+
+describe('getProposedGrade (regression: empty weighted grades no longer NaN)', () => {
+  const scales = [
+    { grade_value: 0, name: 'F' },
+    { grade_value: 3, name: 'C' },
+  ] as API.GradeScale[];
+
+  it('still maps a student with no weighted grade to the lowest scale (average treated as 0)', () => {
+    expect(getProposedGrade([], scales)).toBe('F');
+  });
+
+  it('maps the weighted average onto the matching scale', () => {
+    // average 3 -> reaches the grade_value:3 scale
+    expect(getProposedGrade([exam(1, 3)], scales)).toBe('C');
+  });
+});

--- a/src/pages/TeacherSubjects/components/FinalGradesDetails/utils.ts
+++ b/src/pages/TeacherSubjects/components/FinalGradesDetails/utils.ts
@@ -8,10 +8,12 @@ export const getStudentExamsFromExams = (exams: API.Exam[], student_id: number):
     return [...acc, { ...exam, result }];
   }, []);
 
-export const getProposedGrade = (
-  studentExams: StudentExam[],
-  tutorGradeScales: API.GradeScale[],
-): string => {
+// Weighted average of a student's exam results. Only exams that carry a weight
+// (backend field `exam.weight`) AND a numeric result are counted; everything
+// else is skipped. Returns null when there is no weighted grade to average, or
+// when the result is not finite, so callers can render an empty state instead
+// of a divide-by-zero / NaN value.
+export const getWeightedAverageValue = (studentExams: StudentExam[]): number | null => {
   const [sum, weightsSum] = studentExams.reduce<[number, number]>(
     (acc, { result, weight }) => {
       if (weight && typeof result.result === 'number') {
@@ -23,7 +25,28 @@ export const getProposedGrade = (
     [0, 0],
   );
 
-  const weightedAverage = Number.isNaN(sum / weightsSum) ? 0 : sum / weightsSum;
+  if (weightsSum === 0) return null;
+
+  const average = sum / weightsSum;
+
+  return Number.isFinite(average) ? average : null;
+};
+
+// Display form of the weighted average: mathematically rounded to 2 decimal
+// places, or "-" when there is no weighted grade to average. The Number.EPSILON
+// nudge avoids the classic float half-boundary error (e.g. 1.005 -> "1.01").
+export const getWeightedAverage = (studentExams: StudentExam[]): string => {
+  const value = getWeightedAverageValue(studentExams);
+  if (value === null) return '-';
+
+  return (Math.round((value + Number.EPSILON) * 100) / 100).toFixed(2);
+};
+
+export const getProposedGrade = (
+  studentExams: StudentExam[],
+  tutorGradeScales: API.GradeScale[],
+): string => {
+  const weightedAverage = getWeightedAverageValue(studentExams) ?? 0;
 
   const sortedGradeScales = tutorGradeScales
     .sort((a, b) => a.grade_value - b.grade_value)


### PR DESCRIPTION
Add a "Średnia ważona" (weighted average) column to the ClassRegister,                                                                                                                                                                                                                                              
  positioned left of the existing "Proponowana ocena" column, and surface                                                                                                                                                                                                                                             
  the same value on the FinalGradesDetails screen.                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                      
  The average counts only exams that carry a backend weight and a numeric                                                                                                                                                                                                                                             
  result, is math-rounded to 2 decimal places, and renders "-" when the                                                                                                                                                                                                                                               
  student has no weighted grade (instead of a divide-by-zero 0).                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                      
  Extract getWeightedAverageValue / getWeightedAverage helpers and reuse                                                                                                                                                                                                                                              
  the numeric helper in getProposedGrade so its behavior is unchanged.