### PR TITLE
feat(AN-29): auto-trigger search requests in filter controls

### DIFF
--- a/src/components/AutoSearchProTable/classify.ts
+++ b/src/components/AutoSearchProTable/classify.ts
@@ -1,0 +1,120 @@
+import type { ProColumns } from '@ant-design/pro-table';
+
+/**
+ * The behaviour bucket a search-form control falls into. Drives when an automatic request fires:
+ * - `text`        — debounced request once the value reaches {@link MIN_QUERY_LENGTH} chars.
+ * - `number`      — debounced request (no minimum length).
+ * - `select`      — request immediately on change (if the value actually changed).
+ * - `multiSelect` — request when the control loses focus / dropdown closes (if the value changed).
+ * - `date`        — request immediately on change (if the value changed).
+ * - `off`         — never auto-triggers (column excluded from the search form).
+ */
+export type AutoSearchKind = 'text' | 'number' | 'select' | 'multiSelect' | 'date' | 'off';
+
+const DATE_VALUE_TYPES = new Set([
+  'date',
+  'dateTime',
+  'dateWeek',
+  'dateMonth',
+  'dateQuarter',
+  'dateYear',
+  'dateRange',
+  'dateTimeRange',
+  'time',
+  'timeRange',
+]);
+
+const NUMBER_VALUE_TYPES = new Set(['digit', 'digitRange', 'money', 'percent', 'second']);
+
+const SELECT_VALUE_TYPES = new Set([
+  'select',
+  'checkbox',
+  'radio',
+  'radioButton',
+  'cascader',
+  'treeSelect',
+]);
+
+const MULTIPLE_MODES = new Set(['multiple', 'tags']);
+
+/** Best-effort form field name for a column (matches the key antd/ProForm uses in the search form). */
+export const columnFieldName = <T, V>(column: ProColumns<T, V>): string | undefined => {
+  if (column.key !== undefined && column.key !== null) {
+    return String(column.key);
+  }
+  const { dataIndex } = column;
+  if (dataIndex === undefined || dataIndex === null) {
+    return undefined;
+  }
+  return Array.isArray(dataIndex) ? dataIndex.join('.') : String(dataIndex);
+};
+
+const hasMultipleMode = <T, V>(column: ProColumns<T, V>): boolean => {
+  const fieldProps = column.fieldProps;
+  const mode =
+    fieldProps && typeof fieldProps === 'object'
+      ? (fieldProps as { mode?: string }).mode
+      : undefined;
+  return mode !== undefined && MULTIPLE_MODES.has(mode);
+};
+
+/** Infer the {@link AutoSearchKind} of a column from its ProTable config (before any explicit override). */
+export const inferKind = <T, V>(column: ProColumns<T, V>): AutoSearchKind => {
+  if (column.search === false || column.hideInSearch) {
+    return 'off';
+  }
+
+  const valueType = typeof column.valueType === 'string' ? column.valueType : undefined;
+
+  // A `valueEnum` renders a Select; `mode: multiple`/`tags` makes it a multiselect.
+  if (column.valueEnum) {
+    return hasMultipleMode(column) ? 'multiSelect' : 'select';
+  }
+
+  if (valueType && SELECT_VALUE_TYPES.has(valueType)) {
+    return hasMultipleMode(column) ? 'multiSelect' : 'select';
+  }
+
+  if (valueType && DATE_VALUE_TYPES.has(valueType)) {
+    return 'date';
+  }
+
+  if (valueType && NUMBER_VALUE_TYPES.has(valueType)) {
+    return 'number';
+  }
+
+  // Custom controls injected via `renderFormItem` can't be inspected; default to `select`
+  // (fire-on-change is safe and can be overridden per view via the `autoSearch` prop).
+  if (column.renderFormItem) {
+    return 'select';
+  }
+
+  return 'text';
+};
+
+/**
+ * Build a `fieldName -> AutoSearchKind` map for a set of columns, applying explicit overrides on top
+ * of inference. Columns without a resolvable field name are skipped.
+ */
+export const classifyColumns = <T, V>(
+  columns: ProColumns<T, V>[] | undefined,
+  overrides?: Record<string, AutoSearchKind>,
+): Record<string, AutoSearchKind> => {
+  const kinds: Record<string, AutoSearchKind> = {};
+
+  columns?.forEach((column) => {
+    const name = columnFieldName(column);
+    if (!name) {
+      return;
+    }
+    kinds[name] = inferKind(column);
+  });
+
+  if (overrides) {
+    Object.entries(overrides).forEach(([name, kind]) => {
+      kinds[name] = kind;
+    });
+  }
+
+  return kinds;
+};

--- a/src/components/AutoSearchProTable/classify.ts
+++ b/src/components/AutoSearchProTable/classify.ts
@@ -1,15 +1,35 @@
 import type { ProColumns } from '@ant-design/pro-table';
 
+import { MIN_QUERY_LENGTH, TRIGGER_MODE } from './consts';
+
 /**
- * The behaviour bucket a search-form control falls into. Drives when an automatic request fires:
+ * The kind of control a search field is — the vocabulary used when a page overrides a field via the
+ * `autoSearch` prop. Each kind maps to a {@link AutoSearchTrigger} (see {@link KIND_TO_TRIGGER}):
  * - `text`        — debounced request once the value reaches {@link MIN_QUERY_LENGTH} chars.
  * - `number`      — debounced request (no minimum length).
- * - `select`      — request immediately on change (if the value actually changed).
- * - `multiSelect` — request when the control loses focus / dropdown closes (if the value changed).
- * - `date`        — request immediately on change (if the value changed).
+ * - `select`      — request immediately on change.
+ * - `date`        — request immediately on change.
+ * - `multiSelect` — request when the control loses focus / dropdown closes.
  * - `off`         — never auto-triggers (column excluded from the search form).
  */
 export type AutoSearchKind = 'text' | 'number' | 'select' | 'multiSelect' | 'date' | 'off';
+
+/** When a field fires its request — the three behaviours the controller actually implements. */
+export type AutoSearchTrigger =
+  | { mode: typeof TRIGGER_MODE.DEBOUNCED; minChars: number }
+  | { mode: typeof TRIGGER_MODE.ON_CHANGE }
+  | { mode: typeof TRIGGER_MODE.ON_BLUR }
+  | { mode: typeof TRIGGER_MODE.OFF };
+
+/** Collapses the six user-facing kinds onto the three timing behaviours. */
+export const KIND_TO_TRIGGER: Record<AutoSearchKind, AutoSearchTrigger> = {
+  text: { mode: TRIGGER_MODE.DEBOUNCED, minChars: MIN_QUERY_LENGTH },
+  number: { mode: TRIGGER_MODE.DEBOUNCED, minChars: 0 },
+  select: { mode: TRIGGER_MODE.ON_CHANGE },
+  date: { mode: TRIGGER_MODE.ON_CHANGE },
+  multiSelect: { mode: TRIGGER_MODE.ON_BLUR },
+  off: { mode: TRIGGER_MODE.OFF },
+};
 
 const DATE_VALUE_TYPES = new Set([
   'date',

--- a/src/components/AutoSearchProTable/consts.ts
+++ b/src/components/AutoSearchProTable/consts.ts
@@ -1,0 +1,5 @@
+/** Minimum number of characters a text filter must contain before it auto-triggers a request. */
+export const MIN_QUERY_LENGTH = 3;
+
+/** Debounce (ms) applied to text/number filters after the user stops typing. */
+export const DEBOUNCE_MS = 2000;

--- a/src/components/AutoSearchProTable/consts.ts
+++ b/src/components/AutoSearchProTable/consts.ts
@@ -3,3 +3,17 @@ export const MIN_QUERY_LENGTH = 3;
 
 /** Debounce (ms) applied to text/number filters after the user stops typing. */
 export const DEBOUNCE_MS = 1000;
+
+/** When a search field fires its request — the timing behaviours the controller implements. */
+export const TRIGGER_MODE = {
+  /** Fire after the user pauses typing (text/number inputs). */
+  DEBOUNCED: 'debounced',
+  /** Fire immediately on change (single select, date). */
+  ON_CHANGE: 'onChange',
+  /** Fire when the control loses focus / dropdown closes (multiselect). */
+  ON_BLUR: 'onBlur',
+  /** Never auto-triggers (non-searchable columns). */
+  OFF: 'off',
+} as const;
+
+export type TriggerMode = (typeof TRIGGER_MODE)[keyof typeof TRIGGER_MODE];

--- a/src/components/AutoSearchProTable/consts.ts
+++ b/src/components/AutoSearchProTable/consts.ts
@@ -2,4 +2,4 @@
 export const MIN_QUERY_LENGTH = 3;
 
 /** Debounce (ms) applied to text/number filters after the user stops typing. */
-export const DEBOUNCE_MS = 2000;
+export const DEBOUNCE_MS = 1000;

--- a/src/components/AutoSearchProTable/index.test.ts
+++ b/src/components/AutoSearchProTable/index.test.ts
@@ -1,0 +1,183 @@
+import type { ProColumns } from '@ant-design/pro-table';
+import { expect } from '@jest/globals';
+
+import type { AutoSearchKind } from './classify';
+import { classifyColumns, inferKind } from './classify';
+import { DEBOUNCE_MS } from './consts';
+import { createAutoSearchController } from './useAutoSearch';
+
+const col = (c: Partial<ProColumns<any>>): ProColumns<any> => c as ProColumns<any>;
+
+describe('classify', () => {
+  it('infers kinds from column config', () => {
+    expect(inferKind(col({ dataIndex: 'name' }))).toBe('text');
+    expect(inferKind(col({ dataIndex: 'name', valueType: 'textarea' }))).toBe('text');
+    expect(inferKind(col({ dataIndex: 'age', valueType: 'digit' }))).toBe('number');
+    expect(inferKind(col({ dataIndex: 'created', valueType: 'dateRange' }))).toBe('date');
+    expect(inferKind(col({ dataIndex: 'status', valueEnum: { a: { text: 'a' } } }))).toBe('select');
+    expect(inferKind(col({ dataIndex: 'role', valueType: 'select' }))).toBe('select');
+    expect(
+      inferKind(col({ dataIndex: 'roles', valueType: 'select', fieldProps: { mode: 'multiple' } })),
+    ).toBe('multiSelect');
+    expect(
+      inferKind(
+        col({ dataIndex: 'status', valueEnum: { a: { text: 'a' } }, fieldProps: { mode: 'tags' } }),
+      ),
+    ).toBe('multiSelect');
+  });
+
+  it('treats renderFormItem columns as select by default', () => {
+    expect(inferKind(col({ dataIndex: 'authors', renderFormItem: () => null }))).toBe('select');
+  });
+
+  it('marks non-searchable columns as off', () => {
+    expect(inferKind(col({ dataIndex: 'id', search: false }))).toBe('off');
+    expect(inferKind(col({ dataIndex: 'id', hideInSearch: true }))).toBe('off');
+  });
+
+  it('classifies a column set and applies overrides on top', () => {
+    const kinds = classifyColumns(
+      [
+        col({ dataIndex: 'name' }),
+        col({ dataIndex: 'authors', renderFormItem: () => null }),
+        col({ key: 'tag', dataIndex: ['tag', 'id'], renderFormItem: () => null }),
+      ],
+      { authors: 'multiSelect' },
+    );
+    expect(kinds).toEqual({ name: 'text', authors: 'multiSelect', tag: 'select' });
+  });
+});
+
+describe('autosearch controller', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  const makeHarness = (kinds: Record<string, AutoSearchKind>) => {
+    let values: Record<string, unknown> = {};
+    const submit = jest.fn();
+    const controller = createAutoSearchController((name) => kinds[name] ?? 'text', {
+      submit,
+      getValue: (name) => values[name],
+      getValues: () => ({ ...values }),
+    });
+    // Mirror reality: the form value is updated before onValuesChange fires.
+    const change = (name: string, value: unknown) => {
+      values[name] = value;
+      controller.onValuesChange({ [name]: value });
+    };
+    const seed = (v: Record<string, unknown>) => {
+      values = { ...v };
+      controller.syncSubmitted({ ...v });
+    };
+    return { controller, submit, change, seed };
+  };
+
+  describe('text', () => {
+    it('does not fire below the minimum length, even after the debounce elapses', () => {
+      const { submit, change } = makeHarness({ q: 'text' });
+      change('q', 'ab');
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('fires once, 2s after the last keystroke of a >=3 char query', () => {
+      const { submit, change } = makeHarness({ q: 'text' });
+      change('q', 'abc');
+      jest.advanceTimersByTime(DEBOUNCE_MS - 1);
+      expect(submit).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets the debounce on each keystroke', () => {
+      const { submit, change } = makeHarness({ q: 'text' });
+      change('q', 'abc');
+      jest.advanceTimersByTime(DEBOUNCE_MS - 500);
+      change('q', 'abcd');
+      jest.advanceTimersByTime(DEBOUNCE_MS - 500);
+      expect(submit).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(500);
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires immediately when a previously-applied text filter is cleared', () => {
+      const { submit, change, seed } = makeHarness({ q: 'text' });
+      seed({ q: 'abcde' });
+      change('q', '');
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when clearing a field that was never applied', () => {
+      const { submit, change } = makeHarness({ q: 'text' });
+      change('q', '');
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('drops a pending trigger when shrunk below the minimum length', () => {
+      const { submit, change } = makeHarness({ q: 'text' });
+      change('q', 'abcde');
+      change('q', 'ab');
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+      expect(submit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('select / date', () => {
+    it('fires immediately on a real change', () => {
+      const { submit, change } = makeHarness({ status: 'select' });
+      change('status', 'published');
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when the value is unchanged from the last request', () => {
+      const { submit, controller } = makeHarness({ status: 'select' });
+      controller.syncSubmitted({ status: 'published' });
+      controller.onValuesChange({ status: 'published' });
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('fires immediately when a select is cleared', () => {
+      const { submit, change, seed } = makeHarness({ status: 'select' });
+      seed({ status: 'published' });
+      change('status', undefined);
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multiselect', () => {
+    it('does not fire on selection, fires once on blur when the value changed', () => {
+      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
+      change('authors', [1]);
+      change('authors', [1, 2]);
+      expect(submit).not.toHaveBeenCalled();
+      controller.onBlur(false);
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire on blur when nothing changed (dropdown opened and closed)', () => {
+      const { submit, controller } = makeHarness({ authors: 'multiSelect' });
+      controller.onBlur(false);
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('does not fire when focus moves to a button (Search/Reset submits on its own)', () => {
+      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
+      change('authors', [1]);
+      controller.onBlur(true);
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on blur when a selection was toggled back to empty', () => {
+      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
+      change('authors', [1]);
+      change('authors', []); // cleared, but nothing was applied before
+      controller.onBlur(false);
+      expect(submit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/AutoSearchProTable/index.test.ts
+++ b/src/components/AutoSearchProTable/index.test.ts
@@ -57,6 +57,8 @@ describe('autosearch controller', () => {
     jest.useRealTimers();
   });
 
+  // The controller diffs the live form snapshot (getValues) against its baseline; the harness mirrors
+  // a real form: `set` mutates the snapshot (deleting a key models a cleared/nil field) then triggers.
   const makeHarness = (kinds: Record<string, AutoSearchKind>) => {
     let values: Record<string, unknown> = {};
     const submit = jest.fn();
@@ -65,29 +67,29 @@ describe('autosearch controller', () => {
       getValue: (name) => values[name],
       getValues: () => ({ ...values }),
     });
-    // Mirror reality: the form value is updated before onValuesChange fires.
-    const change = (name: string, value: unknown) => {
-      values[name] = value;
-      controller.onValuesChange({ [name]: value });
+    const set = (name: string, value: unknown) => {
+      if (value === undefined) delete values[name];
+      else values[name] = value;
+      controller.onValuesChange();
     };
     const seed = (v: Record<string, unknown>) => {
       values = { ...v };
       controller.syncSubmitted({ ...v });
     };
-    return { controller, submit, change, seed };
+    return { controller, submit, set, seed };
   };
 
   describe('text', () => {
     it('does not fire below the minimum length, even after the debounce elapses', () => {
-      const { submit, change } = makeHarness({ q: 'text' });
-      change('q', 'ab');
+      const { submit, set } = makeHarness({ q: 'text' });
+      set('q', 'ab');
       jest.advanceTimersByTime(DEBOUNCE_MS);
       expect(submit).not.toHaveBeenCalled();
     });
 
-    it('fires once, 2s after the last keystroke of a >=3 char query', () => {
-      const { submit, change } = makeHarness({ q: 'text' });
-      change('q', 'abc');
+    it('fires once, one debounce interval after the last keystroke of a >=3 char query', () => {
+      const { submit, set } = makeHarness({ q: 'text' });
+      set('q', 'abc');
       jest.advanceTimersByTime(DEBOUNCE_MS - 1);
       expect(submit).not.toHaveBeenCalled();
       jest.advanceTimersByTime(1);
@@ -95,10 +97,10 @@ describe('autosearch controller', () => {
     });
 
     it('resets the debounce on each keystroke', () => {
-      const { submit, change } = makeHarness({ q: 'text' });
-      change('q', 'abc');
+      const { submit, set } = makeHarness({ q: 'text' });
+      set('q', 'abc');
       jest.advanceTimersByTime(DEBOUNCE_MS - 500);
-      change('q', 'abcd');
+      set('q', 'abcd');
       jest.advanceTimersByTime(DEBOUNCE_MS - 500);
       expect(submit).not.toHaveBeenCalled();
       jest.advanceTimersByTime(500);
@@ -106,22 +108,22 @@ describe('autosearch controller', () => {
     });
 
     it('fires immediately when a previously-applied text filter is cleared', () => {
-      const { submit, change, seed } = makeHarness({ q: 'text' });
+      const { submit, set, seed } = makeHarness({ q: 'text' });
       seed({ q: 'abcde' });
-      change('q', '');
+      set('q', '');
       expect(submit).toHaveBeenCalledTimes(1);
     });
 
     it('does not fire when clearing a field that was never applied', () => {
-      const { submit, change } = makeHarness({ q: 'text' });
-      change('q', '');
+      const { submit, set } = makeHarness({ q: 'text' });
+      set('q', '');
       expect(submit).not.toHaveBeenCalled();
     });
 
     it('drops a pending trigger when shrunk below the minimum length', () => {
-      const { submit, change } = makeHarness({ q: 'text' });
-      change('q', 'abcde');
-      change('q', 'ab');
+      const { submit, set } = makeHarness({ q: 'text' });
+      set('q', 'abcde');
+      set('q', 'ab');
       jest.advanceTimersByTime(DEBOUNCE_MS);
       expect(submit).not.toHaveBeenCalled();
     });
@@ -129,31 +131,38 @@ describe('autosearch controller', () => {
 
   describe('select / date', () => {
     it('fires immediately on a real change', () => {
-      const { submit, change } = makeHarness({ status: 'select' });
-      change('status', 'published');
+      const { submit, set } = makeHarness({ status: 'select' });
+      set('status', 'published');
       expect(submit).toHaveBeenCalledTimes(1);
     });
 
-    it('does not fire when the value is unchanged from the last request', () => {
-      const { submit, controller } = makeHarness({ status: 'select' });
-      controller.syncSubmitted({ status: 'published' });
-      controller.onValuesChange({ status: 'published' });
+    it('does not fire when the value is unchanged from the baseline', () => {
+      const { submit, set, seed } = makeHarness({ status: 'select' });
+      seed({ status: 'published' });
+      set('status', 'published'); // same value -> no diff -> no request
       expect(submit).not.toHaveBeenCalled();
     });
 
-    it('fires immediately when a select is cleared', () => {
-      const { submit, change, seed } = makeHarness({ status: 'select' });
+    it('fires when a select is cleared (even though the change payload is empty)', () => {
+      const { submit, set, seed } = makeHarness({ status: 'select' });
       seed({ status: 'published' });
-      change('status', undefined);
+      set('status', undefined); // cleared: field drops out of the snapshot
       expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires when a date filter set this session is cleared', () => {
+      const { submit, set } = makeHarness({ created: 'date' });
+      set('created', '2024-01-01'); // change -> fires (1)
+      set('created', undefined); // clear -> fires (2)
+      expect(submit).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('multiselect', () => {
     it('does not fire on selection, fires once on blur when the value changed', () => {
-      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
-      change('authors', [1]);
-      change('authors', [1, 2]);
+      const { submit, set, controller } = makeHarness({ authors: 'multiSelect' });
+      set('authors', [1]);
+      set('authors', [1, 2]);
       expect(submit).not.toHaveBeenCalled();
       controller.onBlur(false);
       expect(submit).toHaveBeenCalledTimes(1);
@@ -166,18 +175,19 @@ describe('autosearch controller', () => {
     });
 
     it('does not fire when focus moves to a button (Search/Reset submits on its own)', () => {
-      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
-      change('authors', [1]);
+      const { submit, set, controller } = makeHarness({ authors: 'multiSelect' });
+      set('authors', [1]);
       controller.onBlur(true);
       expect(submit).not.toHaveBeenCalled();
     });
 
-    it('does not fire on blur when a selection was toggled back to empty', () => {
-      const { submit, change, controller } = makeHarness({ authors: 'multiSelect' });
-      change('authors', [1]);
-      change('authors', []); // cleared, but nothing was applied before
+    it('fires once when a multiselect is cleared to empty (and not again on the following blur)', () => {
+      const { submit, set, controller } = makeHarness({ authors: 'multiSelect' });
+      set('authors', [1]); // deferred (dirty), no request yet
+      set('authors', []); // cleared -> fires immediately
+      expect(submit).toHaveBeenCalledTimes(1);
       controller.onBlur(false);
-      expect(submit).not.toHaveBeenCalled();
+      expect(submit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/AutoSearchProTable/index.test.ts
+++ b/src/components/AutoSearchProTable/index.test.ts
@@ -177,11 +177,13 @@ describe('autosearch controller', () => {
       expect(submit).not.toHaveBeenCalled();
     });
 
-    it('does not fire when focus moves to a button (Search/Reset submits on its own)', () => {
+    it('keeps a pending change on blur-to-button, flushing on the next real focus loss', () => {
       const { submit, set, controller } = makeHarness({ authors: 'multiSelect' });
       set('authors', [1]);
-      controller.onBlur(true);
+      controller.onBlur(true); // focus moved to a button (e.g. Search) -> keep pending, no request
       expect(submit).not.toHaveBeenCalled();
+      controller.onBlur(false); // real focus loss -> flush the pending change
+      expect(submit).toHaveBeenCalledTimes(1);
     });
 
     it('fires once when a multiselect is cleared to empty (and not again on the following blur)', () => {

--- a/src/components/AutoSearchProTable/index.test.ts
+++ b/src/components/AutoSearchProTable/index.test.ts
@@ -2,7 +2,7 @@ import type { ProColumns } from '@ant-design/pro-table';
 import { expect } from '@jest/globals';
 
 import type { AutoSearchKind } from './classify';
-import { classifyColumns, inferKind } from './classify';
+import { classifyColumns, inferKind, KIND_TO_TRIGGER } from './classify';
 import { DEBOUNCE_MS } from './consts';
 import { createAutoSearchController } from './useAutoSearch';
 
@@ -62,11 +62,14 @@ describe('autosearch controller', () => {
   const makeHarness = (kinds: Record<string, AutoSearchKind>) => {
     let values: Record<string, unknown> = {};
     const submit = jest.fn();
-    const controller = createAutoSearchController((name) => kinds[name] ?? 'text', {
-      submit,
-      getValue: (name) => values[name],
-      getValues: () => ({ ...values }),
-    });
+    const controller = createAutoSearchController(
+      (name) => KIND_TO_TRIGGER[kinds[name] ?? 'text'],
+      {
+        submit,
+        getValue: (name) => values[name],
+        getValues: () => ({ ...values }),
+      },
+    );
     const set = (name: string, value: unknown) => {
       if (value === undefined) delete values[name];
       else values[name] = value;

--- a/src/components/AutoSearchProTable/index.tsx
+++ b/src/components/AutoSearchProTable/index.tsx
@@ -25,7 +25,7 @@ export type AutoSearchProTableProps<
 /**
  * Drop-in replacement for `ProTable` that automatically fires the search request as the user edits
  * the built-in QueryFilter, alongside (not replacing) the "Search" button. Rules:
- * - text: request after ≥ 3 chars and a 2 s pause; clearing fires immediately.
+ * - text: request after ≥ 3 chars and a 1 s pause; clearing fires immediately.
  * - single select / date: request on change (only if the value changed).
  * - multiselect: single request on dropdown close / focus loss (only if the value changed).
  *

--- a/src/components/AutoSearchProTable/index.tsx
+++ b/src/components/AutoSearchProTable/index.tsx
@@ -61,7 +61,7 @@ function AutoSearchProTable<
     ...form,
     onValuesChange: (changedValues, values) => {
       form?.onValuesChange?.(changedValues, values);
-      auto.onValuesChange(changedValues as Record<string, unknown>);
+      auto.onValuesChange();
     },
   };
 

--- a/src/components/AutoSearchProTable/index.tsx
+++ b/src/components/AutoSearchProTable/index.tsx
@@ -1,0 +1,91 @@
+import type { ProFormInstance } from '@ant-design/pro-form';
+import type { ProTableProps } from '@ant-design/pro-table';
+import ProTable from '@ant-design/pro-table';
+import type { MutableRefObject } from 'react';
+import { useRef } from 'react';
+
+import type { AutoSearchKind } from './classify';
+import { useAutoSearch } from './useAutoSearch';
+
+export type { AutoSearchKind } from './classify';
+
+export type AutoSearchProTableProps<
+  DataType extends Record<string, any>,
+  Params extends Record<string, any> = Record<string, any>,
+  ValueType = 'text',
+> = ProTableProps<DataType, Params, ValueType> & {
+  /**
+   * Per-field override of the inferred control kind, keyed by the column's `dataIndex`/`key`. Use it
+   * for `renderFormItem` columns whose control can't be inferred (e.g. a custom multiselect).
+   * Pass `false` to opt this table out of autosearch entirely.
+   */
+  autoSearch?: Record<string, AutoSearchKind> | false;
+};
+
+/**
+ * Drop-in replacement for `ProTable` that automatically fires the search request as the user edits
+ * the built-in QueryFilter, alongside (not replacing) the "Search" button. Rules:
+ * - text: request after ≥ 3 chars and a 2 s pause; clearing fires immediately.
+ * - single select / date: request on change (only if the value changed).
+ * - multiselect: single request on dropdown close / focus loss (only if the value changed).
+ *
+ * Everything else (columns, request, buttons, i18n) is untouched. Tables with `search={false}` or
+ * `autoSearch={false}` render a plain `ProTable`.
+ */
+function AutoSearchProTable<
+  DataType extends Record<string, any>,
+  Params extends Record<string, any> = Record<string, any>,
+  ValueType = 'text',
+>(props: AutoSearchProTableProps<DataType, Params, ValueType>) {
+  const { autoSearch, ...tableProps } = props;
+
+  const internalFormRef = useRef<ProFormInstance>();
+  const formRef =
+    (tableProps.formRef as MutableRefObject<ProFormInstance | undefined> | undefined) ??
+    internalFormRef;
+
+  const auto = useAutoSearch<DataType, ValueType>({
+    columns: tableProps.columns,
+    overrides: autoSearch === false ? undefined : autoSearch,
+    formRef,
+  });
+
+  const disabled = tableProps.search === false || autoSearch === false;
+  if (disabled) {
+    return <ProTable<DataType, Params, ValueType> {...tableProps} />;
+  }
+
+  const { form, onSubmit, onReset } = tableProps;
+
+  const mergedForm: ProTableProps<DataType, Params, ValueType>['form'] = {
+    ...form,
+    onValuesChange: (changedValues, values) => {
+      form?.onValuesChange?.(changedValues, values);
+      auto.onValuesChange(changedValues as Record<string, unknown>);
+    },
+  };
+
+  const handleSubmit = (params: Params) => {
+    auto.onSubmit();
+    onSubmit?.(params);
+  };
+
+  const handleReset = () => {
+    auto.onReset();
+    onReset?.();
+  };
+
+  return (
+    <div style={{ display: 'contents' }} onBlur={auto.onBlur}>
+      <ProTable<DataType, Params, ValueType>
+        {...tableProps}
+        formRef={formRef}
+        form={mergedForm}
+        onSubmit={handleSubmit}
+        onReset={handleReset}
+      />
+    </div>
+  );
+}
+
+export default AutoSearchProTable;

--- a/src/components/AutoSearchProTable/useAutoSearch.ts
+++ b/src/components/AutoSearchProTable/useAutoSearch.ts
@@ -43,6 +43,8 @@ export const createAutoSearchController = (
 
   /** Snapshot of the form values as of the last request — the baseline for "did it actually change?". */
   let lastSubmitted: Record<string, unknown> = {};
+  /** Last value observed for each field (tracks in-session edits, independent of the submit snapshot). */
+  const prev: Record<string, unknown> = {};
   /** Multiselect fields touched since the last request; flushed on blur / dropdown close. */
   const dirty = new Set<string>();
   const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -79,21 +81,34 @@ export const createAutoSearchController = (
   };
 
   return {
-    /** Wire to the search form's `onValuesChange`. */
-    onValuesChange(changed: Record<string, unknown>) {
-      Object.entries(changed ?? {}).forEach(([name, value]) => {
+    /**
+     * Wire to the search form's `onValuesChange` — but used only as a trigger. ProForm strips nil
+     * values from the change payload, so a cleared field is invisible there; instead we re-read the
+     * whole form via `getValues()` and diff it against the tracked baseline to find what changed.
+     */
+    onValuesChange() {
+      const current = deps.getValues() ?? {};
+      const names = new Set<string>([...Object.keys(prev), ...Object.keys(current)]);
+
+      names.forEach((name) => {
+        const value = current[name];
+        const previous = prev[name];
+        if (isEqual(value, previous)) {
+          return;
+        }
+        prev[name] = value;
+
         const kind = getKind(name);
         if (kind === 'off') {
           return;
         }
 
-        // Clearing a filter fires a fresh request immediately (regardless of control type) — but
-        // only when it actually removes a previously-applied value, so emptying an already-empty
-        // field (or toggling a multiselect option on then off) doesn't fire a spurious request.
+        // Field cleared — refetch only if it actually held a value (so emptying an already-empty
+        // field doesn't fire a spurious request).
         if (isEmptyValue(value)) {
           clearTimer(name);
           dirty.delete(name);
-          if (!isEmptyValue(lastSubmitted[name]) && !isEqual(value, lastSubmitted[name])) {
+          if (!isEmptyValue(previous)) {
             doSubmit();
           }
           return;
@@ -113,9 +128,8 @@ export const createAutoSearchController = (
             break;
           case 'select':
           case 'date':
-            if (!isEqual(value, lastSubmitted[name])) {
-              doSubmit();
-            }
+            // The diff above already confirmed a real change from the last observed value.
+            doSubmit();
             break;
           case 'multiSelect':
             dirty.add(name);
@@ -152,6 +166,10 @@ export const createAutoSearchController = (
       clearAllTimers();
       dirty.clear();
       lastSubmitted = { ...(values ?? {}) };
+      // Keep the per-field baseline in sync so a later clear compares against the applied state
+      // (and a Reset, which passes {}, drops any stale per-field values).
+      Object.keys(prev).forEach((key) => delete prev[key]);
+      Object.assign(prev, lastSubmitted);
     },
 
     dispose() {
@@ -196,11 +214,19 @@ export const useAutoSearch = <T, V>({
     );
   }
 
-  useEffect(() => () => controllerRef.current?.dispose(), []);
+  useEffect(() => {
+    // Seed the baseline from the form's initial values (set by ProTable before this effect runs),
+    // so clearing a pre-populated filter — one never touched via onValuesChange nor a submit —
+    // is still recognised as removing a value and refetches.
+    const initial = formRef.current?.getFieldsValue?.() as Record<string, unknown> | undefined;
+    if (initial && Object.keys(initial).length > 0) {
+      controllerRef.current?.syncSubmitted(initial);
+    }
+    return () => controllerRef.current?.dispose();
+  }, []);
 
   return {
-    onValuesChange: (changed: Record<string, unknown>) =>
-      controllerRef.current?.onValuesChange(changed),
+    onValuesChange: () => controllerRef.current?.onValuesChange(),
     onSubmit: () =>
       controllerRef.current?.syncSubmitted(
         formRef.current?.getFieldsValue?.() as Record<string, unknown>,

--- a/src/components/AutoSearchProTable/useAutoSearch.ts
+++ b/src/components/AutoSearchProTable/useAutoSearch.ts
@@ -129,11 +129,10 @@ export const createAutoSearchController = (
 
     /**
      * Wire to a blur handler on the search-form container. Flushes pending multiselect changes when
-     * focus leaves the control. Skips when focus moved to a button (e.g. "Search"/"Reset"), which
-     * submits on its own — avoids a duplicate request.
+     * focus leaves the control, unless focus went to a button (see below).
      */
     onBlur(relatedIsButton: boolean) {
-      if (dirty.size === 0) {
+      if (relatedIsButton || dirty.size === 0) {
         return;
       }
       let changedAny = false;
@@ -143,7 +142,7 @@ export const createAutoSearchController = (
         }
       });
       dirty.clear();
-      if (changedAny && !relatedIsButton) {
+      if (changedAny) {
         doSubmit();
       }
     },
@@ -211,7 +210,12 @@ export const useAutoSearch = <T, V>({ columns, overrides, formRef }: UseAutoSear
       controllerRef.current?.syncSubmitted(
         formRef.current?.getFieldsValue?.() as Record<string, unknown>,
       ),
-    onReset: () => controllerRef.current?.syncSubmitted({}),
+    onReset: () =>
+      // ProTable's Reset restores column initialValues, so baseline from the post-reset form state
+      // (not {}) — otherwise clearing a field that has an initialValue wouldn't refetch afterwards.
+      controllerRef.current?.syncSubmitted(
+        formRef.current?.getFieldsValue?.() as Record<string, unknown>,
+      ),
     onBlur: (event: React.FocusEvent<HTMLElement>) => {
       const related = event.relatedTarget as HTMLElement | null;
       const isButton = !!related && (related.tagName === 'BUTTON' || !!related.closest('button'));

--- a/src/components/AutoSearchProTable/useAutoSearch.ts
+++ b/src/components/AutoSearchProTable/useAutoSearch.ts
@@ -1,7 +1,7 @@
 import type { ProFormInstance } from '@ant-design/pro-form';
 import type { ProColumns } from '@ant-design/pro-table';
 import type { MutableRefObject } from 'react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import isEqual from 'lodash/isEqual';
 
@@ -66,7 +66,11 @@ export const createAutoSearchController = (
       name,
       setTimeout(() => {
         timers.delete(name);
-        doSubmit();
+        // Guard against a redundant submit: if an ON_CHANGE field in the same batch already fired
+        // doSubmit() (re-baselining lastSubmitted) before this timer ran, the value is unchanged.
+        if (!isEqual(deps.getValue(name), lastSubmitted[name])) {
+          doSubmit();
+        }
       }, DEBOUNCE_MS),
     );
   };
@@ -204,22 +208,33 @@ export const useAutoSearch = <T, V>({ columns, overrides, formRef }: UseAutoSear
     return () => controllerRef.current?.dispose();
   }, []);
 
-  return {
-    onValuesChange: () => controllerRef.current?.onValuesChange(),
-    onSubmit: () =>
+  // Handlers are stabilised with useCallback so their identity is referentially stable across
+  // renders. controllerRef/formRef are refs (stable), so empty/ref-only deps never go stale.
+  const onValuesChange = useCallback(() => controllerRef.current?.onValuesChange(), []);
+
+  const onSubmit = useCallback(
+    () =>
       controllerRef.current?.syncSubmitted(
         formRef.current?.getFieldsValue?.() as Record<string, unknown>,
       ),
-    onReset: () =>
+    [formRef],
+  );
+
+  const onReset = useCallback(
+    () =>
       // ProTable's Reset restores column initialValues, so baseline from the post-reset form state
       // (not {}) — otherwise clearing a field that has an initialValue wouldn't refetch afterwards.
       controllerRef.current?.syncSubmitted(
         formRef.current?.getFieldsValue?.() as Record<string, unknown>,
       ),
-    onBlur: (event: React.FocusEvent<HTMLElement>) => {
-      const related = event.relatedTarget as HTMLElement | null;
-      const isButton = !!related && (related.tagName === 'BUTTON' || !!related.closest('button'));
-      controllerRef.current?.onBlur(isButton);
-    },
-  };
+    [formRef],
+  );
+
+  const onBlur = useCallback((event: React.FocusEvent<HTMLElement>) => {
+    const related = event.relatedTarget as HTMLElement | null;
+    const isButton = !!related && (related.tagName === 'BUTTON' || !!related.closest('button'));
+    controllerRef.current?.onBlur(isButton);
+  }, []);
+
+  return { onValuesChange, onSubmit, onReset, onBlur };
 };

--- a/src/components/AutoSearchProTable/useAutoSearch.ts
+++ b/src/components/AutoSearchProTable/useAutoSearch.ts
@@ -5,9 +5,9 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import isEqual from 'lodash/isEqual';
 
-import type { AutoSearchKind } from './classify';
-import { classifyColumns } from './classify';
-import { DEBOUNCE_MS, MIN_QUERY_LENGTH } from './consts';
+import type { AutoSearchKind, AutoSearchTrigger } from './classify';
+import { classifyColumns, KIND_TO_TRIGGER } from './classify';
+import { DEBOUNCE_MS, TRIGGER_MODE } from './consts';
 
 export interface AutoSearchDeps {
   /** Trigger the actual request (ProTable form submit). */
@@ -16,11 +16,6 @@ export interface AutoSearchDeps {
   getValue: (name: string) => unknown;
   /** Read the current values of the whole search form. */
   getValues: () => Record<string, unknown>;
-}
-
-export interface AutoSearchOptions {
-  minChars?: number;
-  debounceMs?: number;
 }
 
 const isEmptyValue = (value: unknown): boolean =>
@@ -34,13 +29,9 @@ const isEmptyValue = (value: unknown): boolean =>
  * logic can be unit-tested directly with fake timers and a stub {@link AutoSearchDeps}.
  */
 export const createAutoSearchController = (
-  getKind: (name: string) => AutoSearchKind,
+  getTrigger: (name: string) => AutoSearchTrigger,
   deps: AutoSearchDeps,
-  options: AutoSearchOptions = {},
 ) => {
-  const minChars = options.minChars ?? MIN_QUERY_LENGTH;
-  const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
-
   /** Snapshot of the form values as of the last request — the baseline for "did it actually change?". */
   let lastSubmitted: Record<string, unknown> = {};
   /** Last value observed for each field (tracks in-session edits, independent of the submit snapshot). */
@@ -76,7 +67,7 @@ export const createAutoSearchController = (
       setTimeout(() => {
         timers.delete(name);
         doSubmit();
-      }, debounceMs),
+      }, DEBOUNCE_MS),
     );
   };
 
@@ -98,8 +89,8 @@ export const createAutoSearchController = (
         }
         prev[name] = value;
 
-        const kind = getKind(name);
-        if (kind === 'off') {
+        const trigger = getTrigger(name);
+        if (trigger.mode === TRIGGER_MODE.OFF) {
           return;
         }
 
@@ -114,24 +105,20 @@ export const createAutoSearchController = (
           return;
         }
 
-        switch (kind) {
-          case 'text':
-            if (String(value).length >= minChars) {
+        switch (trigger.mode) {
+          case TRIGGER_MODE.DEBOUNCED:
+            // Text has a minimum length (numbers pass minChars: 0); shorter input drops the trigger.
+            if (String(value).length >= trigger.minChars) {
               scheduleDebounced(name);
             } else {
-              // 1-2 non-empty chars: never auto-fire; drop any pending trigger.
               clearTimer(name);
             }
             break;
-          case 'number':
-            scheduleDebounced(name);
-            break;
-          case 'select':
-          case 'date':
+          case TRIGGER_MODE.ON_CHANGE:
             // The diff above already confirmed a real change from the last observed value.
             doSubmit();
             break;
-          case 'multiSelect':
+          case TRIGGER_MODE.ON_BLUR:
             dirty.add(name);
             break;
           default:
@@ -184,19 +171,13 @@ export interface UseAutoSearchArgs<T, V> {
   columns?: ProColumns<T, V>[];
   overrides?: Record<string, AutoSearchKind>;
   formRef: MutableRefObject<ProFormInstance | undefined>;
-  options?: AutoSearchOptions;
 }
 
 /**
  * React binding for {@link createAutoSearchController}. Returns handlers to wire into ProTable's
  * search form (`onValuesChange`), submit/reset hooks, and a container blur handler.
  */
-export const useAutoSearch = <T, V>({
-  columns,
-  overrides,
-  formRef,
-  options,
-}: UseAutoSearchArgs<T, V>) => {
+export const useAutoSearch = <T, V>({ columns, overrides, formRef }: UseAutoSearchArgs<T, V>) => {
   const kinds = useMemo(() => classifyColumns(columns, overrides), [columns, overrides]);
   const kindsRef = useRef(kinds);
   kindsRef.current = kinds;
@@ -204,13 +185,12 @@ export const useAutoSearch = <T, V>({
   const controllerRef = useRef<AutoSearchController>();
   if (!controllerRef.current) {
     controllerRef.current = createAutoSearchController(
-      (name) => kindsRef.current[name] ?? 'text',
+      (name) => KIND_TO_TRIGGER[kindsRef.current[name] ?? 'text'],
       {
         submit: () => formRef.current?.submit(),
         getValue: (name) => formRef.current?.getFieldValue(name),
         getValues: () => (formRef.current?.getFieldsValue?.() as Record<string, unknown>) ?? {},
       },
-      options,
     );
   }
 

--- a/src/components/AutoSearchProTable/useAutoSearch.ts
+++ b/src/components/AutoSearchProTable/useAutoSearch.ts
@@ -1,0 +1,215 @@
+import type { ProFormInstance } from '@ant-design/pro-form';
+import type { ProColumns } from '@ant-design/pro-table';
+import type { MutableRefObject } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+
+import isEqual from 'lodash/isEqual';
+
+import type { AutoSearchKind } from './classify';
+import { classifyColumns } from './classify';
+import { DEBOUNCE_MS, MIN_QUERY_LENGTH } from './consts';
+
+export interface AutoSearchDeps {
+  /** Trigger the actual request (ProTable form submit). */
+  submit: () => void;
+  /** Read the current value of a single filter field. */
+  getValue: (name: string) => unknown;
+  /** Read the current values of the whole search form. */
+  getValues: () => Record<string, unknown>;
+}
+
+export interface AutoSearchOptions {
+  minChars?: number;
+  debounceMs?: number;
+}
+
+const isEmptyValue = (value: unknown): boolean =>
+  value === undefined ||
+  value === null ||
+  value === '' ||
+  (Array.isArray(value) && value.length === 0);
+
+/**
+ * Framework-agnostic engine implementing the autosearch rules. Kept free of React so the decision
+ * logic can be unit-tested directly with fake timers and a stub {@link AutoSearchDeps}.
+ */
+export const createAutoSearchController = (
+  getKind: (name: string) => AutoSearchKind,
+  deps: AutoSearchDeps,
+  options: AutoSearchOptions = {},
+) => {
+  const minChars = options.minChars ?? MIN_QUERY_LENGTH;
+  const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
+
+  /** Snapshot of the form values as of the last request — the baseline for "did it actually change?". */
+  let lastSubmitted: Record<string, unknown> = {};
+  /** Multiselect fields touched since the last request; flushed on blur / dropdown close. */
+  const dirty = new Set<string>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const clearTimer = (name: string) => {
+    const timer = timers.get(name);
+    if (timer) {
+      clearTimeout(timer);
+      timers.delete(name);
+    }
+  };
+
+  const clearAllTimers = () => {
+    timers.forEach((timer) => clearTimeout(timer));
+    timers.clear();
+  };
+
+  const doSubmit = () => {
+    clearAllTimers();
+    dirty.clear();
+    deps.submit();
+    lastSubmitted = { ...deps.getValues() };
+  };
+
+  const scheduleDebounced = (name: string) => {
+    clearTimer(name);
+    timers.set(
+      name,
+      setTimeout(() => {
+        timers.delete(name);
+        doSubmit();
+      }, debounceMs),
+    );
+  };
+
+  return {
+    /** Wire to the search form's `onValuesChange`. */
+    onValuesChange(changed: Record<string, unknown>) {
+      Object.entries(changed ?? {}).forEach(([name, value]) => {
+        const kind = getKind(name);
+        if (kind === 'off') {
+          return;
+        }
+
+        // Clearing a filter fires a fresh request immediately (regardless of control type) — but
+        // only when it actually removes a previously-applied value, so emptying an already-empty
+        // field (or toggling a multiselect option on then off) doesn't fire a spurious request.
+        if (isEmptyValue(value)) {
+          clearTimer(name);
+          dirty.delete(name);
+          if (!isEmptyValue(lastSubmitted[name]) && !isEqual(value, lastSubmitted[name])) {
+            doSubmit();
+          }
+          return;
+        }
+
+        switch (kind) {
+          case 'text':
+            if (String(value).length >= minChars) {
+              scheduleDebounced(name);
+            } else {
+              // 1-2 non-empty chars: never auto-fire; drop any pending trigger.
+              clearTimer(name);
+            }
+            break;
+          case 'number':
+            scheduleDebounced(name);
+            break;
+          case 'select':
+          case 'date':
+            if (!isEqual(value, lastSubmitted[name])) {
+              doSubmit();
+            }
+            break;
+          case 'multiSelect':
+            dirty.add(name);
+            break;
+          default:
+            break;
+        }
+      });
+    },
+
+    /**
+     * Wire to a blur handler on the search-form container. Flushes pending multiselect changes when
+     * focus leaves the control. Skips when focus moved to a button (e.g. "Search"/"Reset"), which
+     * submits on its own — avoids a duplicate request.
+     */
+    onBlur(relatedIsButton: boolean) {
+      if (dirty.size === 0) {
+        return;
+      }
+      let changedAny = false;
+      dirty.forEach((name) => {
+        if (!isEqual(deps.getValue(name), lastSubmitted[name])) {
+          changedAny = true;
+        }
+      });
+      dirty.clear();
+      if (changedAny && !relatedIsButton) {
+        doSubmit();
+      }
+    },
+
+    /** Re-baseline after a request that did not originate here (the "Search"/"Reset" buttons). */
+    syncSubmitted(values?: Record<string, unknown>) {
+      clearAllTimers();
+      dirty.clear();
+      lastSubmitted = { ...(values ?? {}) };
+    },
+
+    dispose() {
+      clearAllTimers();
+    },
+  };
+};
+
+export type AutoSearchController = ReturnType<typeof createAutoSearchController>;
+
+export interface UseAutoSearchArgs<T, V> {
+  columns?: ProColumns<T, V>[];
+  overrides?: Record<string, AutoSearchKind>;
+  formRef: MutableRefObject<ProFormInstance | undefined>;
+  options?: AutoSearchOptions;
+}
+
+/**
+ * React binding for {@link createAutoSearchController}. Returns handlers to wire into ProTable's
+ * search form (`onValuesChange`), submit/reset hooks, and a container blur handler.
+ */
+export const useAutoSearch = <T, V>({
+  columns,
+  overrides,
+  formRef,
+  options,
+}: UseAutoSearchArgs<T, V>) => {
+  const kinds = useMemo(() => classifyColumns(columns, overrides), [columns, overrides]);
+  const kindsRef = useRef(kinds);
+  kindsRef.current = kinds;
+
+  const controllerRef = useRef<AutoSearchController>();
+  if (!controllerRef.current) {
+    controllerRef.current = createAutoSearchController(
+      (name) => kindsRef.current[name] ?? 'text',
+      {
+        submit: () => formRef.current?.submit(),
+        getValue: (name) => formRef.current?.getFieldValue(name),
+        getValues: () => (formRef.current?.getFieldsValue?.() as Record<string, unknown>) ?? {},
+      },
+      options,
+    );
+  }
+
+  useEffect(() => () => controllerRef.current?.dispose(), []);
+
+  return {
+    onValuesChange: (changed: Record<string, unknown>) =>
+      controllerRef.current?.onValuesChange(changed),
+    onSubmit: () =>
+      controllerRef.current?.syncSubmitted(
+        formRef.current?.getFieldsValue?.() as Record<string, unknown>,
+      ),
+    onReset: () => controllerRef.current?.syncSubmitted({}),
+    onBlur: (event: React.FocusEvent<HTMLElement>) => {
+      const related = event.relatedTarget as HTMLElement | null;
+      const isButton = !!related && (related.tagName === 'BUTTON' || !!related.closest('button'));
+      controllerRef.current?.onBlur(isButton);
+    },
+  };
+};

--- a/src/components/CourseTopicsStatistics/GiftQuizStatistics.tsx
+++ b/src/components/CourseTopicsStatistics/GiftQuizStatistics.tsx
@@ -1,8 +1,9 @@
-import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { type ProColumns } from '@ant-design/pro-table';
 import { format } from 'date-fns';
 import React, { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { getTopicStats } from '@/services/escola-lms/course';
@@ -129,7 +130,7 @@ export const GiftQuizStatistics: React.FC<Props> = ({ quizTopics }) => {
   }, []);
 
   return (
-    <ProTable<API.GiftQuizTopicStat, TableParams>
+    <AutoSearchProTable<API.GiftQuizTopicStat, TableParams>
       headerTitle={<FormattedMessage id="TopicStatistics.giftQuiz.title" />}
       onSubmit={({ topic_id }) => setSelectedTopicId(topic_id)}
       onReset={() => setSelectedTopicId(quizTopics?.[0]?.id)}

--- a/src/components/LogsWidget/index.tsx
+++ b/src/components/LogsWidget/index.tsx
@@ -1,9 +1,9 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { track } from '@/services/escola-lms/tracker';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { format } from 'date-fns';
 import React, { useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -56,7 +56,7 @@ const LogsWidget: React.FC<{ useAsWidget?: boolean; userID?: number }> = ({
   const [loading, setLoading] = useState(false);
   const intl = useIntl();
   return (
-    <ProTable<
+    <AutoSearchProTable<
       EscolaLms.Tracker.Models.TrackRoute,
       API.PageParams & {
         user_id?: number;

--- a/src/components/ProjectsList/index.tsx
+++ b/src/components/ProjectsList/index.tsx
@@ -1,11 +1,12 @@
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import type { ActionType } from '@ant-design/pro-table';
-import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { type ProColumns } from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, Typography, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import ProjectSolutionFeedbackDrawer from '@/components/ProjectsList/ProjectSolutionFeedbackDrawer';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
@@ -201,7 +202,7 @@ export const ProjectsList: React.FC<Props> = ({ courseId }) => {
 
   return (
     <>
-      <ProTable
+      <AutoSearchProTable
         actionRef={actionRef}
         headerTitle={intl.formatMessage({
           id: 'project_solutions',

--- a/src/components/UsersSubmissions/index.tsx
+++ b/src/components/UsersSubmissions/index.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from 'umi';
 
 import { Button, message, Popconfirm, Tag, Tooltip } from 'antd';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import {
   assignUserSubmission,
   deleteUserSubmission,
@@ -12,7 +13,6 @@ import {
 import { createTableOrderObject } from '@/utils/utils';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import AddUserSubmission from './form';
 import './index.css';
 
@@ -83,7 +83,7 @@ export const UserSubmissions: React.FC<{
   );
   return (
     <Fragment>
-      <ProTable<
+      <AutoSearchProTable<
         EscolaLms.AssignWithoutAccount.Models.UserSubmission,
         API.PageParams & { email?: string; morphable_id?: number; morphable_type?: string }
       >

--- a/src/pages/Categories/index.tsx
+++ b/src/pages/Categories/index.tsx
@@ -1,8 +1,8 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { Tree } from '@/components/Tree';
 import { PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Modal, Popconfirm, Spin, Tag, Tooltip, message } from 'antd';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { IntlShape } from 'react-intl';
@@ -250,7 +250,7 @@ const TableList: React.FC = () => {
       <Modal open={showTree} onCancel={() => setShowTree(false)} onOk={() => setShowTree(false)}>
         {showTree && <TreeModal />}
       </Modal>
-      <ProTable<API.CategoryListItem, API.CategoryParams>
+      <AutoSearchProTable<API.CategoryListItem, API.CategoryParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Courses.Categories',
           defaultMessage: 'categories',

--- a/src/pages/CompetencyChallenges/index.tsx
+++ b/src/pages/CompetencyChallenges/index.tsx
@@ -1,11 +1,12 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
-import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { type ProColumns } from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
 import React from 'react';
 import { FormattedMessage, Link } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import {
@@ -127,7 +128,7 @@ const staticColumns: ProColumns<API.CompetencyChallenge>[] = [
 
 const CompetencyChallenges: React.FC = () => (
   <PageContainer>
-    <ProTable<API.CompetencyChallenge, API.CompetencyChallengesParams>
+    <AutoSearchProTable<API.CompetencyChallenge, API.CompetencyChallengesParams>
       rowKey="id"
       search={{ layout: 'vertical' }}
       toolBarRender={() => [

--- a/src/pages/Consultations/index.tsx
+++ b/src/pages/Consultations/index.tsx
@@ -1,3 +1,4 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import CategoryTree from '@/components/CategoryTree';
 import ModelFields from '@/components/ModelFields';
 import { DATETIME_FORMAT, DAY_FORMAT } from '@/consts/dates';
@@ -17,7 +18,6 @@ import {
 import ProCard from '@ant-design/pro-card';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Select, Tag, Tooltip, Typography, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -268,7 +268,7 @@ const Consultations: React.FC = () => {
         }}
       >
         <ProCard.TabPane key="list" tab={<FormattedMessage id="list" />}>
-          <ProTable<API.Consultation, API.ConsultationsParams>
+          <AutoSearchProTable<API.Consultation, API.ConsultationsParams>
             headerTitle={intl.formatMessage({
               id: 'Consultations',
               defaultMessage: 'Consultations',

--- a/src/pages/ConsultationsAccess/index.tsx
+++ b/src/pages/ConsultationsAccess/index.tsx
@@ -1,10 +1,11 @@
 import { PageContainer } from '@ant-design/pro-layout';
-import ProTable, { type ActionType, type ProColumns } from '@ant-design/pro-table';
+import { type ActionType, type ProColumns } from '@ant-design/pro-table';
 import { Button, Space, Tag } from 'antd';
 import { format } from 'date-fns';
 import React, { useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { CollectionSelect } from '@/components/CollectionSelect';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
@@ -202,7 +203,7 @@ const TableList: React.FC = () => {
         onSuccess={() => actionRef.current?.reload()}
       />
 
-      <ProTable
+      <AutoSearchProTable
         headerTitle={intl.formatMessage({
           id: 'menu.Other activities.Consultation Requests',
         })}

--- a/src/pages/CourseAccess/index.tsx
+++ b/src/pages/CourseAccess/index.tsx
@@ -3,12 +3,12 @@ import { DATETIME_FORMAT } from '@/consts/dates';
 import { DeleteOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Drawer, Popconfirm, Tag, Tooltip, Typography, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { CollectionSelect } from '@/components/CollectionSelect';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import {
@@ -206,7 +206,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.CourseAccessEnquiryListItem, API.CourseAccessEnquiryListParams>
+      <AutoSearchProTable<API.CourseAccessEnquiryListItem, API.CourseAccessEnquiryListParams>
         headerTitle={intl.formatMessage({
           id: 'courseAccessEnquiries',
           defaultMessage: 'Course Access Enquiries',

--- a/src/pages/Courses/components/CourseQuizReports.tsx
+++ b/src/pages/Courses/components/CourseQuizReports.tsx
@@ -1,12 +1,12 @@
 import { FileSearchOutlined } from '@ant-design/icons';
 import type { ProFormInstance, ProTableProps } from '@ant-design/pro-components';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
 import React, { useCallback, useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { getQuizAttempts } from '@/services/escola-lms/gift_quiz';
@@ -159,7 +159,7 @@ export const CourseQuizReports: React.FC<{ courseId: number }> = ({ courseId }) 
   );
 
   return (
-    <ProTable<API.QuizAttempt, API.QuizAttemptsParams>
+    <AutoSearchProTable<API.QuizAttempt, API.QuizAttemptsParams>
       headerTitle={intl.formatMessage({
         id: 'quiz_reports',
         defaultMessage: 'Quiz Reports',

--- a/src/pages/Courses/index.tsx
+++ b/src/pages/Courses/index.tsx
@@ -10,11 +10,11 @@ import {
 import ProCard from '@ant-design/pro-card';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip, Typography, message } from 'antd';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import CategoryTree from '@/components/CategoryTree';
 import SecureUpload from '@/components/SecureUpload';
 import Tags from '@/components/Tags';
@@ -374,7 +374,7 @@ const TableList: React.FC = () => {
           </a>
         </ProCard>
       </ProCard>{' '}
-      <ProTable<API.CourseListItem, API.CourseParams>
+      <AutoSearchProTable<API.CourseListItem, API.CourseParams>
         loading={loading}
         headerTitle={intl.formatMessage({
           id: 'menu.Courses',
@@ -385,6 +385,7 @@ const TableList: React.FC = () => {
         search={{
           layout: 'vertical',
         }}
+        autoSearch={{ authors: 'multiSelect', tag: 'multiSelect' }}
         request={(
           { pageSize, current, title, active, category_id, tag, status, authors },
           sort,

--- a/src/pages/Dictionary/components/DictionaryWords/index.tsx
+++ b/src/pages/Dictionary/components/DictionaryWords/index.tsx
@@ -1,3 +1,4 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import SecureUpload from '@/components/SecureUpload';
 import PERMISSIONS from '@/consts/permissions';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -6,7 +7,6 @@ import { deleteDictionaryWord, dictionaryWords } from '@/services/escola-lms/dic
 import { createTableOrderObject } from '@/utils/utils';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip, message } from 'antd';
 import React, { useRef } from 'react';
 import { FormattedMessage, Link, useIntl, useParams } from 'umi';
@@ -96,7 +96,7 @@ const DictionaryWordsTableList: React.FC = () => {
   ];
 
   return (
-    <ProTable<API.DictionaryWords, API.DictionaryWordsParams>
+    <AutoSearchProTable<API.DictionaryWords, API.DictionaryWordsParams>
       headerTitle={intl.formatMessage({
         id: 'words',
         defaultMessage: 'Words',
@@ -116,11 +116,11 @@ const DictionaryWordsTableList: React.FC = () => {
           </Button>
         </Link>,
         checkPermission(PERMISSIONS.DictionaryImport) ? (
-          <div className='import-dictionary'>
+          <div className="import-dictionary">
             <SecureUpload
               title={intl.formatMessage({
                 id: 'import_dictionary',
-                defaultMessage: 'Import dictionary'
+                defaultMessage: 'Import dictionary',
               })}
               url="/api/admin/dictionary-words/import"
               name="file"

--- a/src/pages/Dictionary/index.tsx
+++ b/src/pages/Dictionary/index.tsx
@@ -1,14 +1,14 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
+import { DictionaryTabNames } from '@/pages/Dictionary/form';
 import { deleteDictionary, dictionaries } from '@/services/escola-lms/dictionary';
 import { createTableOrderObject } from '@/utils/utils';
-import { DictionaryTabNames } from '@/pages/Dictionary/form';
 
 const handleRemove = async (id: number) => {
   return deleteDictionary(id).then((response) => {
@@ -86,7 +86,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Dictionaries, API.DictionariesParams>
+      <AutoSearchProTable<API.Dictionaries, API.DictionariesParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Other activities.Dictionary',
           defaultMessage: 'Dictionary',

--- a/src/pages/H5P/index.tsx
+++ b/src/pages/H5P/index.tsx
@@ -1,4 +1,5 @@
 import AuthenticatedLinkButton from '@/components/AuthenticatedLinkButton';
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import UploadH5P from '@/components/H5P/upload';
 import { h5p, removeH5P } from '@/services/escola-lms/h5p';
 import { createTableOrderObject } from '@/utils/utils';
@@ -11,7 +12,6 @@ import {
 } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
@@ -159,7 +159,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.H5PContentListItem, API.H5PListParams>
+      <AutoSearchProTable<API.H5PContentListItem, API.H5PListParams>
         loading={loading}
         headerTitle={intl.formatMessage({
           id: 'menu.Courses.H5Ps',

--- a/src/pages/Notifications/index.tsx
+++ b/src/pages/Notifications/index.tsx
@@ -5,11 +5,11 @@ import { getEventTypes, getNotifications } from '@/services/escola-lms/notificat
 import { createTableOrderObject } from '@/utils/utils';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { format } from 'date-fns';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { getEventType } from '@/components/NoticeIcon/NoticeList';
 
 export const TableColumns: ProColumns<API.Notification>[] = [
@@ -80,7 +80,7 @@ const NotificationsPage: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Notification>
+      <AutoSearchProTable<API.Notification>
         headerTitle={intl.formatMessage({
           id: 'notifications',
           defaultMessage: 'notifications',

--- a/src/pages/Orders/index.tsx
+++ b/src/pages/Orders/index.tsx
@@ -1,11 +1,11 @@
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Space, Tag } from 'antd';
 import { format } from 'date-fns';
 import React, { useRef } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import UserSelect from '@/components/UserSelect';
 import { orders } from '@/services/escola-lms/orders';
 
@@ -177,7 +177,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<
+      <AutoSearchProTable<
         API.OrderListItem,
         API.PageParams &
           EscolaLms.Cart.Http.Requests.Admin.OrderSearchRequest & {

--- a/src/pages/Pages/index.tsx
+++ b/src/pages/Pages/index.tsx
@@ -1,11 +1,11 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { deletePage, pages } from '@/services/escola-lms/pages';
 import { createTableOrderObject } from '@/utils/utils';
@@ -96,7 +96,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.PageListItem, API.PageParams>
+      <AutoSearchProTable<API.PageListItem, API.PageParams>
         headerTitle={intl.formatMessage({
           id: 'pages',
           defaultMessage: 'pages',

--- a/src/pages/Payments/index.tsx
+++ b/src/pages/Payments/index.tsx
@@ -1,12 +1,12 @@
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import React, { useRef } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 import { payments } from '@/services/escola-lms/payments';
 import { format } from 'date-fns';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { createTableOrderObject, roundTo } from '@/utils/utils';
@@ -117,7 +117,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<
+      <AutoSearchProTable<
         API.PaymentListItem,
         API.PageParams & { dateRange: [string, string]; status: API.PaymentStatus }
       >

--- a/src/pages/Products/index.tsx
+++ b/src/pages/Products/index.tsx
@@ -1,11 +1,11 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Space, Tag, Tooltip, Typography, message } from 'antd';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import type { PossibleType } from '@/components/TypeButtonDrawer';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { createTableOrderObject } from '@/utils/utils';
@@ -182,7 +182,7 @@ const Products: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<
+      <AutoSearchProTable<
         EscolaLms.Cart.Models.Product,
         API.PageParams &
           API.PaginationParams &

--- a/src/pages/Questionnaire/components/Answers.tsx
+++ b/src/pages/Questionnaire/components/Answers.tsx
@@ -1,3 +1,4 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
 import { DATETIME_FORMAT } from '@/consts/dates';
@@ -7,7 +8,6 @@ import {
 } from '@/services/escola-lms/questionnaire';
 import ProForm, { ProFormSwitch } from '@ant-design/pro-form';
 import type { ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Form, message } from 'antd';
 import { format } from 'date-fns';
 import { useMemo } from 'react';
@@ -175,7 +175,7 @@ const QuestionAnswers: React.FC<{
   ];
 
   return (
-    <ProTable<
+    <AutoSearchProTable<
       API.QuestionAnswer,
       API.PageParams & { question_id?: number; user_id?: string; date?: string }
     >

--- a/src/pages/Questionnaire/components/Questions.tsx
+++ b/src/pages/Questionnaire/components/Questions.tsx
@@ -1,8 +1,8 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { addQuestion, deleteQuestion, editQuestion } from '@/services/escola-lms/questionnaire';
 import { sortArrayByKey } from '@/utils/utils';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -121,7 +121,7 @@ const QuestionForm: React.FC<{
 
   return (
     <>
-      <ProTable
+      <AutoSearchProTable
         headerTitle={intl.formatMessage({
           id: 'question_list',
           defaultMessage: 'question_list',

--- a/src/pages/Questionnaire/index.tsx
+++ b/src/pages/Questionnaire/index.tsx
@@ -1,9 +1,9 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { deleteQuestionnaire, questionnaire } from '@/services/escola-lms/questionnaire';
 import { createTableOrderObject } from '@/utils/utils';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useCallback, useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
@@ -56,7 +56,7 @@ const Questionnaire: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Questionnaire>
+      <AutoSearchProTable<API.Questionnaire>
         headerTitle={intl.formatMessage({
           id: 'questionnaires',
           defaultMessage: 'questionnaires',

--- a/src/pages/QuizReports/index.tsx
+++ b/src/pages/QuizReports/index.tsx
@@ -1,12 +1,12 @@
 import { FileSearchOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
 import React, { useCallback, useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import CourseSelect from '@/components/CourseSelect';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
@@ -213,7 +213,7 @@ const QuizAttempts: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.QuizAttempt, API.QuizAttemptsParams>
+      <AutoSearchProTable<API.QuizAttempt, API.QuizAttemptsParams>
         headerTitle={intl.formatMessage({
           id: 'quiz_reports',
           defaultMessage: 'Quiz Reports',

--- a/src/pages/Roles/index.tsx
+++ b/src/pages/Roles/index.tsx
@@ -1,8 +1,8 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { createRole, deleteRole, roles } from '@/services/escola-lms/roles';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip } from 'antd';
 import React, { useRef, useState } from 'react';
 import { FormattedMessage, Link, history, useIntl } from 'umi';
@@ -33,7 +33,7 @@ const RolesPage: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Role>
+      <AutoSearchProTable<API.Role>
         headerTitle={intl.formatMessage({
           id: 'menu.Users.Roles',
           defaultMessage: 'roles',

--- a/src/pages/Scorm/index.tsx
+++ b/src/pages/Scorm/index.tsx
@@ -1,10 +1,10 @@
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useRef } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import UploadScorm from '@/components/Scorm/upload';
 import { deleteScorm, scorms } from '@/services/escola-lms/scorm';
 import { DeleteOutlined, SendOutlined } from '@ant-design/icons';
@@ -108,7 +108,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.SCORM, API.PageParams & { search: string; role: string }>
+      <AutoSearchProTable<API.SCORM, API.PageParams & { search: string; role: string }>
         headerTitle={intl.formatMessage({
           id: 'menu.Courses.SCORMs',
           defaultMessage: 'scorms',

--- a/src/pages/Settings/package.tsx
+++ b/src/pages/Settings/package.tsx
@@ -1,7 +1,7 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { sortArrayByKey } from '@/utils/utils';
 import { EditOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tag, Tooltip } from 'antd';
 import React, { useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -112,7 +112,7 @@ const TableList: React.FC<{
 
   return (
     <React.Fragment>
-      <ProTable<API.ConfigEntry>
+      <AutoSearchProTable<API.ConfigEntry>
         headerTitle={intl.formatMessage({
           id: 'menu.settings',
         })}

--- a/src/pages/Settings/user.tsx
+++ b/src/pages/Settings/user.tsx
@@ -1,11 +1,11 @@
 import { PlusOutlined } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip, message } from 'antd';
 import React, { useRef, useState } from 'react';
 import type { IntlShape } from 'react-intl';
 import { FormattedMessage, useIntl, useModel } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import {
   createSettings,
   deleteSettings,
@@ -184,7 +184,7 @@ const TableList: React.FC = () => {
 
   return (
     <React.Fragment>
-      <ProTable<API.Setting, API.PageParams & { group: string }>
+      <AutoSearchProTable<API.Setting, API.PageParams & { group: string }>
         headerTitle={intl.formatMessage({
           id: 'menu.settings',
         })}

--- a/src/pages/StationaryEvents/index.tsx
+++ b/src/pages/StationaryEvents/index.tsx
@@ -1,9 +1,9 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { deleteStationaryEvent, stationaryEvents } from '@/services/escola-lms/stationary_events';
 import { createTableOrderObject } from '@/utils/utils';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
@@ -72,7 +72,7 @@ const StationaryEvents: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<
+      <AutoSearchProTable<
         EscolaLms.StationaryEvents.Models.StationaryEvent,
         API.PageParams & API.PaginationParams & { name: string }
       >

--- a/src/pages/Tasks/index.tsx
+++ b/src/pages/Tasks/index.tsx
@@ -1,9 +1,9 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import UserSelect from '@/components/UserSelect';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useRef } from 'react';
@@ -151,7 +151,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.TaskListItem, API.TaskListParams>
+      <AutoSearchProTable<API.TaskListItem, API.TaskListParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Other activities.Tasks',
           defaultMessage: 'Tasks',

--- a/src/pages/TeacherSubjects/components/Attendances.tsx
+++ b/src/pages/TeacherSubjects/components/Attendances.tsx
@@ -1,11 +1,11 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { message } from 'antd';
 import { format } from 'date-fns';
 import React, { useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 import AttendanceCheckbox from '@/components/AttendanceCheckbox';
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { DAY_FORMAT } from '@/consts/dates';
 import { groupAttendanceSchedule as fetchGroupAttendanceSchedule } from '@/services/escola-lms/attendances';
 import { studentUserGroup as fetchStudentUserGroup } from '@/services/escola-lms/student_user_groups';
@@ -56,7 +56,7 @@ export const Attendances: React.FC = () => {
   );
 
   return (
-    <ProTable<AttendanceTableItem, AttendanceTableFilters>
+    <AutoSearchProTable<AttendanceTableItem, AttendanceTableFilters>
       className="table-standalone"
       headerTitle={`${intl.formatMessage({
         id: 'attendances',

--- a/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
+++ b/src/pages/TeacherSubjects/components/ClassRegister/index.tsx
@@ -1,9 +1,9 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Modal, Spin, Table, Tooltip, message } from 'antd';
 import React, { useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import BookmarkNoteModal from '@/components/BookmarkNoteModal';
 import PERMISSIONS from '@/consts/permissions';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -194,7 +194,7 @@ export const ClassRegister: React.FC = () => {
           pointer-events:none on the content, so no per-student write can race
           the bulk write. */}
       <Spin spinning={togglingScheduleId !== null}>
-        <ProTable<ClassRegisterTableItem>
+        <AutoSearchProTable<ClassRegisterTableItem>
           sticky
           className="table-standalone"
           request={async ({ group_id = groupOptions[0]?.value, full_name = '' }) => {

--- a/src/pages/TeacherSubjects/components/FileExportsHistory.tsx
+++ b/src/pages/TeacherSubjects/components/FileExportsHistory.tsx
@@ -1,11 +1,11 @@
 import { DownloadOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tooltip } from 'antd';
 import { format } from 'date-fns';
 import React, { useMemo } from 'react';
 import { FormattedMessage } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import UserSelect from '@/components/UserSelect';
 import { DATETIME_FORMAT } from '@/consts/dates';
@@ -142,7 +142,7 @@ export const FileExportsHistory: React.FC = () => {
   );
 
   return (
-    <ProTable<API.PCGFileExportsHistoryItem, API.PCGFileExportsHistoryParams>
+    <AutoSearchProTable<API.PCGFileExportsHistoryItem, API.PCGFileExportsHistoryParams>
       className="table-standalone"
       request={async ({
         group_id = teacherSubjectData?.groups?.[0]?.id,

--- a/src/pages/TeacherSubjects/components/FinalGradesList.tsx
+++ b/src/pages/TeacherSubjects/components/FinalGradesList.tsx
@@ -1,10 +1,10 @@
 import { EditOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tooltip, Typography } from 'antd';
 import React, { useMemo } from 'react';
 import { FormattedMessage, Link, useLocation } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import TypeButtonDrawer from '@/components/TypeButtonDrawer';
 import { getGroupFinalGrades } from '@/services/escola-lms/grades';
 import { useTeacherSubject } from '../context';
@@ -64,7 +64,7 @@ export const FinalGradesList: React.FC = () => {
   }
 
   return (
-    <ProTable<API.FinalGradeItem, TableParams>
+    <AutoSearchProTable<API.FinalGradeItem, TableParams>
       className="table-standalone"
       rowKey="id"
       search={{ layout: 'vertical' }}

--- a/src/pages/TeacherSubjects/components/Students.tsx
+++ b/src/pages/TeacherSubjects/components/Students.tsx
@@ -1,9 +1,10 @@
 import { getGroupFinalGrades as fetchGroupFinalGrades } from '@/services/escola-lms/grades';
-import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { type ProColumns } from '@ant-design/pro-table';
 import type { DefaultOptionType } from 'antd/lib/select';
 import React, { useMemo } from 'react';
 import { FormattedMessage } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { allStudentsAndGroups as fetchAllStudentsAndGroups } from '@/services/escola-lms/student_user_groups';
 import { useTeacherSubject } from '../context';
 import { CreateTeamsChatButton } from './CreateTeamsChatButton';
@@ -94,7 +95,7 @@ export const Students: React.FC = () => {
   );
 
   return (
-    <ProTable<TableDataProps, TableParams>
+    <AutoSearchProTable<TableDataProps, TableParams>
       className="table-standalone"
       rowKey={(record) => `${record.group_id}-${record.user_id}`}
       search={{ layout: 'vertical' }}

--- a/src/pages/TeacherSubjects/index.tsx
+++ b/src/pages/TeacherSubjects/index.tsx
@@ -1,9 +1,9 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import SemesterSelect from '@/components/SemesterSelect';
 import { semesterSubjects } from '@/services/escola-lms/semester_subject';
 import { EditOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tooltip } from 'antd';
 import React, { useRef, useState } from 'react';
 import { FormattedMessage, Link, history, useIntl, useLocation } from 'umi';
@@ -75,7 +75,7 @@ const TableList: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Subjects, API.SubjectParams>
+      <AutoSearchProTable<API.Subjects, API.SubjectParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Teacher.Subjects',
           defaultMessage: 'Subjects',

--- a/src/pages/Templates/ConfigList/index.tsx
+++ b/src/pages/Templates/ConfigList/index.tsx
@@ -1,8 +1,8 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import { deleteTemplate, templates } from '@/services/escola-lms/templates';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tag, Tooltip, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useCallback, useRef, useState } from 'react';
@@ -91,7 +91,7 @@ const TableList: React.FC<{ templateType: string; channel: channelType }> = ({
   );
 
   return (
-    <ProTable<API.TemplateListItem, API.TemplatesParams>
+    <AutoSearchProTable<API.TemplateListItem, API.TemplatesParams>
       headerTitle={intl.formatMessage({
         id: 'templates',
         defaultMessage: 'templates',

--- a/src/pages/Translations/admin.tsx
+++ b/src/pages/Translations/admin.tsx
@@ -1,3 +1,4 @@
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import {
   createTranslation,
   translations,
@@ -8,7 +9,6 @@ import { localeInfo } from '@@/plugin-locale/localeExports';
 import { EditOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Tooltip } from 'antd';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, addLocale, getAllLocales, useIntl } from 'umi';
@@ -85,7 +85,7 @@ const Translations: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<LangRow>
+      <AutoSearchProTable<LangRow>
         headerTitle={intl.formatMessage({
           id: 'menu.Configuration.Translations',
           defaultMessage: 'Translations',

--- a/src/pages/Translations/index.tsx
+++ b/src/pages/Translations/index.tsx
@@ -1,10 +1,10 @@
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Tag, Typography } from 'antd';
 import React, { Fragment, useCallback, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import {
   createTranslation,
   deleteTranslation,
@@ -85,7 +85,7 @@ const Translations: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<
+      <AutoSearchProTable<
         API.Translation,
         API.PageParams &
           API.PaginationParams & {

--- a/src/pages/UserGroups/index.tsx
+++ b/src/pages/UserGroups/index.tsx
@@ -4,11 +4,11 @@ import { deleteUserGroup, userGroups, userGroupsTree } from '@/services/escola-l
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Modal, Popconfirm, Spin, Tag, Tooltip } from 'antd';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { Tree } from '@/components/Tree';
 import { createTableOrderObject } from '@/utils/utils';
 
@@ -149,7 +149,7 @@ const TableList: React.FC = () => {
       <Modal open={showTree} onCancel={() => setShowTree(false)} onOk={() => setShowTree(false)}>
         {showTree && <TreeModal />}
       </Modal>
-      <ProTable<API.UserGroup, API.UserGroupsParams>
+      <AutoSearchProTable<API.UserGroup, API.UserGroupsParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Users.User Groups',
           defaultMessage: 'User Groups',

--- a/src/pages/Users/index.tsx
+++ b/src/pages/Users/index.tsx
@@ -14,9 +14,10 @@ import {
 } from '@ant-design/icons';
 import ProCard from '@ant-design/pro-card';
 import { PageContainer } from '@ant-design/pro-layout';
-import ProTable, { type ProColumns } from '@ant-design/pro-table';
+import { type ProColumns } from '@ant-design/pro-table';
 
 import AuthenticatedLinkButton from '@/components/AuthenticatedLinkButton';
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import SecureUpload from '@/components/SecureUpload';
 import { DATETIME_FORMAT } from '@/consts/dates';
 import useModelFields from '@/hooks/useModelFields';
@@ -287,7 +288,7 @@ const TableList: React.FC = () => {
         }}
       >
         <ProCard.TabPane key="list" tab={<FormattedMessage id="list" />}>
-          <ProTable<
+          <AutoSearchProTable<
             API.UserListItem,
             API.PageParams &
               API.PaginationParams &

--- a/src/pages/Vouchers/index.tsx
+++ b/src/pages/Vouchers/index.tsx
@@ -1,12 +1,12 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import { Button, Popconfirm, Tooltip, message } from 'antd';
 import { format } from 'date-fns';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import { deleteVoucher } from '@/services/escola-lms/vouchers';
 
 import { DATETIME_FORMAT, DAY_FORMAT } from '@/consts/dates';
@@ -128,7 +128,7 @@ const Vouchers: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable
+      <AutoSearchProTable
         headerTitle={intl.formatMessage({
           id: 'menu.Sales.Vouchers',
           defaultMessage: 'Vouchers',

--- a/src/pages/Webinars/index.tsx
+++ b/src/pages/Webinars/index.tsx
@@ -1,6 +1,5 @@
 import { PageContainer } from '@ant-design/pro-layout';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
 import React, { useCallback, useRef, useState } from 'react';
 import { FormattedMessage, Link, useIntl } from 'umi';
 
@@ -16,6 +15,7 @@ import {
 import { Button, Popconfirm, Select, Tag, Tooltip, Typography, message } from 'antd';
 import { format } from 'date-fns';
 
+import AutoSearchProTable from '@/components/AutoSearchProTable';
 import Tags from '@/components/Tags';
 import { DATETIME_FORMAT, DAY_FORMAT } from '@/consts/dates';
 
@@ -212,7 +212,7 @@ const Webinars: React.FC = () => {
 
   return (
     <PageContainer>
-      <ProTable<API.Webinar, API.WebinarsParams>
+      <AutoSearchProTable<API.Webinar, API.WebinarsParams>
         headerTitle={intl.formatMessage({
           id: 'menu.Courses.Webinars',
           defaultMessage: 'Webinars',
@@ -223,6 +223,7 @@ const Webinars: React.FC = () => {
         search={{
           layout: 'vertical',
         }}
+        autoSearch={{ tag: 'multiSelect' }}
         toolBarRender={() => [
           <Link key="addnew" to="/courses/webinars/new">
             <Button type="primary" key="primary">


### PR DESCRIPTION
Add an AutoSearchProTable wrapper that fires the ProTable search request                                                                                                                                                                                                                                            
  automatically as the user edits the built-in filter form, alongside the                                                                                                                                                                                                                                             
  unchanged "Search" button:                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                      
  - text: request after >=3 chars and a 2s debounce; clearing fires                                                                                                                                                                                                                                                   
    immediately (1-2 chars never auto-fire)                                                                                                                                                                                                                                                                           
  - single select / date: request on change, only when the value changed                                                                                                                                                                                                                                              
  - multiselect: single request on dropdown close / focus loss, only when                                                                                                                                                                                                                                             
    the value changed                                                                                                                                                                                                                                                                                                 
  - clearing any applied filter fires a request without clicking "Search"                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                      
  The wrapper is a drop-in replacement for ProTable (same props and                                                                                                                                                                                                                                                   
  generics) plus an optional `autoSearch` override map for control kinds                                                                                                                                                                                                                                              
  that can't be inferred from column config (renderFormItem multiselects);                                                                                                                                                                                                                                            
  all other kinds are auto-detected from valueType/valueEnum/fieldProps.                                                                                                                                                                                                                                              
  Multiselect close/blur is detected via a bubbling onBlur, so custom                                                                                                                                                                                                                                                 
  select components need no changes. The "Search"/"Reset" buttons and each                                                                                                                                                                                                                                            
  page's request logic are untouched.                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                      
  Rolled out to all search-enabled list views and widgets; search={false}                                                                                                                                                                                                                                             
  tables are left as plain ProTable. Rules engine covered by unit tests.