### PR TITLE
fix: fix playwright e2e tests

### DIFF
--- a/.github/workflows/e2e-playwright.js.yml
+++ b/.github/workflows/e2e-playwright.js.yml
@@ -73,8 +73,14 @@ jobs:
           MAIL_ENCRYPTION: ""
           MJML_BINARY_PATH: /usr/bin/mjml
           TRACKER_ENABLED: "false"
+        # escolalms/api:latest is a php-fpm-only image (supervisord runs php-fpm +
+        # horizon + scheduler, no web server), so publishing php-fpm's port speaks
+        # FastCGI, not HTTP, and the browser cannot reach the API. We instead run
+        # Laravel's built-in HTTP server inside the container on 8080 (see the
+        # "Start API HTTP server" step) and publish that to the host on :80, which
+        # is the origin the frontend is built against (REACT_APP_API_URL).
         ports:
-          - 80:80
+          - 80:8080
         options: >-
           --name api
 
@@ -97,6 +103,29 @@ jobs:
       - run: docker exec -u 0 api php artisan passport:client --personal --no-interaction
       - run: docker exec -u 0 api php artisan db:seed --force --no-interaction
       - run: docker exec -u 0 api chmod -R 777 storage bootstrap/cache
+
+      # The image has no HTTP web server, only php-fpm. Start Laravel's built-in
+      # server so the e2e browser has a real HTTP endpoint. Runs detached, after
+      # chmod so it can write to storage/, and logs to /tmp/serve.log inside the
+      # container so the readiness gate below can surface failures.
+      - name: Start API HTTP server
+        run: docker exec -d -u 0 api sh -c 'php artisan serve --host=0.0.0.0 --port=8080 > /tmp/serve.log 2>&1'
+
+      # Fail fast (and visibly) if the API never serves HTTP, instead of letting
+      # every spec silently time out at the login step. Any HTTP status proves the
+      # server is reachable; on failure, dump the server + container logs.
+      - name: Wait for API to serve HTTP
+        run: |
+          for i in $(seq 1 40); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/settings || echo 000)
+            if [ "$code" != "000" ]; then echo "API serving HTTP (status $code)"; exit 0; fi
+            echo "waiting for API HTTP... attempt $i"; sleep 3
+          done
+          echo "::error::API never served HTTP on :80"
+          echo "----- artisan serve log -----"; docker exec api cat /tmp/serve.log || true
+          echo "----- docker logs api (tail) -----"; docker logs api 2>&1 | tail -200 || true
+          docker ps -a || true
+          exit 1
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-playwright.js.yml
+++ b/.github/workflows/e2e-playwright.js.yml
@@ -73,14 +73,11 @@ jobs:
           MAIL_ENCRYPTION: ""
           MJML_BINARY_PATH: /usr/bin/mjml
           TRACKER_ENABLED: "false"
-        # escolalms/api:latest is a php-fpm-only image (supervisord runs php-fpm +
-        # horizon + scheduler, no web server), so publishing php-fpm's port speaks
-        # FastCGI, not HTTP, and the browser cannot reach the API. We instead run
-        # Laravel's built-in HTTP server inside the container on 8080 (see the
-        # "Start API HTTP server" step) and publish that to the host on :80, which
-        # is the origin the frontend is built against (REACT_APP_API_URL).
-        ports:
-          - 80:8080
+        # escolalms/api:latest is a php-fpm-only image (php-fpm on :9000, no bundled
+        # web server), so the browser cannot talk to it directly. An nginx reverse-
+        # proxy (see the "Start nginx reverse-proxy" step) owns host :80 — the origin
+        # the frontend is built against — and forwards FastCGI to this service at
+        # api:9000 over the docker network, so the service itself publishes no port.
         options: >-
           --name api
 
@@ -104,32 +101,39 @@ jobs:
       - run: docker exec -u 0 api php artisan db:seed --force --no-interaction
       - run: docker exec -u 0 api chmod -R 777 storage bootstrap/cache
 
-      # The image has no HTTP web server, only php-fpm. Start Laravel's built-in
-      # server so the e2e browser has a real HTTP endpoint. Runs detached, after
-      # chmod so it can write to storage/, and logs to /tmp/serve.log inside the
-      # container so the readiness gate below can surface failures.
-      - name: Start API HTTP server
-        run: docker exec -d -u 0 api sh -c 'php artisan serve --host=0.0.0.0 --port=8080 > /tmp/serve.log 2>&1'
-
-      # Fail fast (and visibly) if the API never serves HTTP, instead of letting
-      # every spec silently time out at the login step. Any HTTP status proves the
-      # server is reachable; on failure, dump the server + container logs.
-      - name: Wait for API to serve HTTP
-        run: |
-          for i in $(seq 1 40); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/settings || echo 000)
-            if [ "$code" != "000" ]; then echo "API serving HTTP (status $code)"; exit 0; fi
-            echo "waiting for API HTTP... attempt $i"; sleep 3
-          done
-          echo "::error::API never served HTTP on :80"
-          echo "----- artisan serve log -----"; docker exec api cat /tmp/serve.log || true
-          echo "----- docker logs api (tail) -----"; docker logs api 2>&1 | tail -200 || true
-          docker ps -a || true
-          exit 1
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      # escolalms/api:latest has no web server (php-fpm only). Run an nginx reverse-
+      # proxy on the same docker network as the services, owning host :80 and
+      # forwarding FastCGI to php-fpm at api:9000. Its config is mounted from the repo
+      # (available now that checkout ran). This is the HTTP origin the e2e browser hits.
+      - name: Start nginx reverse-proxy
+        run: |
+          NET=$(docker inspect api --format '{{range $k,$_ := .NetworkSettings.Networks}}{{$k}}{{end}}')
+          echo "api is on docker network: $NET"
+          docker run -d --name apinginx --network "$NET" -p 80:80 \
+            -v "$PWD/config/nginx-e2e.conf":/etc/nginx/conf.d/default.conf:ro \
+            nginx:alpine
+
+      # Fail fast (and visibly) if the API never serves HTTP, instead of letting
+      # every spec silently time out at the login step. Any HTTP status proves the
+      # proxy + php-fpm are reachable; on failure, dump the nginx + api logs.
+      - name: Wait for API to serve HTTP
+        run: |
+          for i in $(seq 1 40); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/settings 2>/dev/null || true)
+            case "$code" in
+              ''|000) echo "waiting for API HTTP... attempt $i (last: ${code:-none})"; sleep 3 ;;
+              *) echo "API serving HTTP (status $code)"; exit 0 ;;
+            esac
+          done
+          echo "::error::API never served HTTP on :80"
+          echo "----- docker logs apinginx -----"; docker logs apinginx 2>&1 | tail -50 || true
+          echo "----- docker logs api (tail) -----"; docker logs api 2>&1 | tail -200 || true
+          docker ps -a || true
+          exit 1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e-playwright.js.yml
+++ b/.github/workflows/e2e-playwright.js.yml
@@ -38,6 +38,11 @@ jobs:
 
       redis:
         image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
       api:
         image: escolalms/api:latest
@@ -73,6 +78,13 @@ jobs:
           MAIL_ENCRYPTION: ""
           MJML_BINARY_PATH: /usr/bin/mjml
           TRACKER_ENABLED: "false"
+          # The e2e specs drive the admin UI synchronously and never wait on queued
+          # jobs, so the Horizon worker and scheduler aren't needed. Disabling them
+          # cuts their root-owned writes to storage/, which otherwise race php-fpm
+          # (uid 1000) mid-run. NOTE: the `chmod -R 777` step below is still required
+          # — php-fpm writes logs/cache/sessions to storage/ at request time.
+          DISABLE_HORIZON: "true"
+          DISABLE_SCHEDULER: "true"
         # escolalms/api:latest is a php-fpm-only image (php-fpm on :9000, no bundled
         # web server), so the browser cannot talk to it directly. An nginx reverse-
         # proxy (see the "Start nginx reverse-proxy" step) owns host :80 — the origin

--- a/.github/workflows/e2e-playwright.js.yml
+++ b/.github/workflows/e2e-playwright.js.yml
@@ -30,70 +30,85 @@ jobs:
           TZ: Europe/Warsaw
         ports:
           - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U default -d default"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
       redis:
         image: redis
 
       api:
         image: escolalms/api:latest
+        # Config must be passed at container-start time: GitHub boots service
+        # containers before any step runs, and the escolalms/api entrypoint
+        # connects to the DB on boot. Without these it falls back to Laravel
+        # defaults (db "forge") and dies with "Connection refused".
+        env:
+          APP_NAME: Wellms Playwright Demo
+          APP_ENV: local
+          APP_KEY: base64:pveos6JL8iCwO3MbzoyQpNx6TETMYuUpfZ18CDKl6Cw=
+          APP_DEBUG: "true"
+          APP_LOG_LEVEL: debug
+          APP_URL: http://localhost
+          DB_CONNECTION: pgsql
+          DB_HOST: postgres
+          DB_PORT: "5432"
+          DB_DATABASE: default
+          DB_USERNAME: default
+          DB_PASSWORD: secret
+          BROADCAST_DRIVER: log
+          CACHE_DRIVER: redis
+          SESSION_DRIVER: cookie
+          QUEUE_DRIVER: redis
+          QUEUE_CONNECTION: redis
+          REDIS_HOST: redis
+          REDIS_PORT: "6379"
+          REDIS_PASSWORD: ""
+          LARAVEL_REDIS_PASSWORD: ""
+          MAIL_DRIVER: smtp
+          MAIL_HOST: mailhog
+          MAIL_PORT: "1025"
+          MAIL_ENCRYPTION: ""
+          MJML_BINARY_PATH: /usr/bin/mjml
+          TRACKER_ENABLED: "false"
         ports:
           - 80:80
-
         options: >-
-          --name api  --env LARAVEL_REDIS_PASSWORD= --env VAR2=value2
-
+          --name api
 
     steps:
+      # escolalms/api:latest no longer ships the mjml binary at MJML_BINARY_PATH,
+      # so template rendering dies with "sh: /usr/bin/mjml: not found". Drop in a
+      # passthrough stub (stdin -> stdout) when the real binary is absent; the e2e
+      # specs exercise the admin UI, not email-HTML fidelity, so passthrough is fine.
       - run: |
-          docker exec -u 1000 api echo "APP_NAME=Wellms Playwright Demo \
-          APP_ENV=local \
-          APP_KEY=base64:pveos6JL8iCwO3MbzoyQpNx6TETMYuUpfZ18CDKl6Cw= \
-          APP_DEBUG=true \
-          APP_LOG_LEVEL=debug \
-          APP_URL=http://localhost:1000 \
-          DB_CONNECTION=pgsql \
-          DB_HOST=postgres \ 
-          DB_PORT=5432 \
-          DB_DATABASE=default \
-          DB_USERNAME=default \
-          DB_PASSWORD=secret \
-          BROADCAST_DRIVER=log \
-          CACHE_DRIVER=redis \
-          SESSION_DRIVER=cookie \
-          QUEUE_DRIVER=redis \
-          QUEUE_CONNECTION=redis \
-          REDIS_HOST=redis \
-          REDIS_PASSWORD= \
-          REDIS_PORT=6379 \
-          MAIL_DRIVER=smtp \
-          MAIL_HOST=mailhog \
-          MAIL_PORT=1025 \
-          MAIL_USERNAME=null \
-          MAIL_PASSWORD=null \
-          MAIL_ENCRYPTION= \
-          MJML_BINARY_PATH=/usr/bin/mjml \
-          TRACKER_ENABLED=false" >> .env
+          docker exec -u 0 api sh -c '[ -x /usr/bin/mjml ] || { printf "#!/bin/sh\ncat\n" > /usr/bin/mjml; chmod +x /usr/bin/mjml; }'
+      # The escolalms/api image ships storage/ and bootstrap/cache owned by root,
+      # and its background daemons (horizon/scheduler) also write there as root, so
+      # forcing uid 1000 here hits "Permission denied" on logs and seeded dirs.
+      # Run the one-off setup as root, then make the writable trees world-writable
+      # so php-fpm — which serves the app as uid 1000 during the tests — can write.
+      - run: docker exec -u 0 api php artisan config:cache
+      - run: docker exec -u 0 api composer dumpautoload
+      - run: docker exec -u 0 api php artisan passport:keys --force --no-interaction
+      - run: docker exec -u 0 api php artisan migrate --force --no-interaction
+      - run: docker exec -u 0 api php artisan passport:client --personal --no-interaction
+      - run: docker exec -u 0 api php artisan db:seed --force --no-interaction
+      - run: docker exec -u 0 api chmod -R 777 storage bootstrap/cache
 
-      - run: docker exec -u 1000 api cat .env
-      - run: docker exec -u 1000 api php artisan config:cache
-      - run: docker exec -u 1000 api composer dumpautoload
-      - run: docker exec -u 1000 api php artisan key:generate --force --no-interaction
-      - run: docker exec -u 1000 api php artisan passport:keys --force --no-interaction
-      - run: docker exec -u 1000 api php artisan migrate --force --no-interaction
-      - run: docker exec -u 1000 api php artisan passport:client --personal --no-interaction
-      - run: docker exec -u 1000 api php artisan db:seed --force --no-interaction
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -122,7 +137,7 @@ jobs:
         run: npm run test:e2e
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results

--- a/config/nginx-e2e.conf
+++ b/config/nginx-e2e.conf
@@ -1,0 +1,26 @@
+# nginx reverse-proxy for the e2e CI backend.
+#
+# escolalms/api:latest is a php-fpm-only image (php-fpm on :9000, no bundled web
+# server), so the browser cannot talk to it directly. This proxies HTTP on :80 to
+# php-fpm at api:9000 (the api service's network-alias), with the Laravel document
+# root as php-fpm sees it inside its own container. All requests route through
+# index.php — fine for the API (the e2e specs only hit /api/*), and nginx never
+# needs the app's files because SCRIPT_FILENAME is resolved on the php-fpm side.
+server {
+    listen 80 default_server;
+    server_name _;
+    root /var/www/html/public;
+    index index.php;
+
+    location / {
+        try_files $uri /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass api:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /var/www/html/public$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+    }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,10 @@ const config: PlaywrightTestConfig = {
   //testMatch: ['src/**/.*(test|spec).(js|ts|mjs)'],
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  // Laravel's built-in server (used in CI) is single-threaded, and the specs share
+  // one admin login and create/delete named records — run serially in CI to avoid
+  // request contention and cross-spec data races.
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? 'github' : 'list',
   use: {
     headless: true,

--- a/src/e2e/consts.ts
+++ b/src/e2e/consts.ts
@@ -1,5 +1,7 @@
 export const BASE_URL = `http://localhost:${process.env.PORT || 8000}`;
+// The escolalms/api seed creates the admin as admin2@escolalms.com (there is no
+// plain admin@escolalms.com); admin2 has the `admin` role.
 export const ADMIN_CREDENTIALS = {
-  email: 'admin@escolalms.com',
+  email: 'admin2@escolalms.com',
   password: 'secret',
 };

--- a/src/e2e/helpers.ts
+++ b/src/e2e/helpers.ts
@@ -10,7 +10,10 @@ export const loginAsAdmin = async (page: Page) => {
   await page.locator('input[id="password"]').fill(ADMIN_CREDENTIALS.password);
   await page.locator('form button').click();
 
-  await expect(page).toHaveURL(`${BASE_URL}/#/welcome`, { timeout: 10000 });
+  // Post-login the app awaits several bootstrap calls (profile, settings, packages,
+  // translations) before redirecting; allow generous time as the CI API is served
+  // by a single-threaded dev server.
+  await expect(page).toHaveURL(`${BASE_URL}/#/welcome`, { timeout: 30000 });
 };
 
 // Helper function to confirm deletion of a record in a table

--- a/src/e2e/login.e2e.spec.ts
+++ b/src/e2e/login.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { ADMIN_CREDENTIALS, BASE_URL } from './consts';
 
 test(`test route page login`, async ({ page }) => {
@@ -8,6 +8,7 @@ test(`test route page login`, async ({ page }) => {
   await page.locator('input[id="email"]').fill(ADMIN_CREDENTIALS.email);
   await page.locator('input[id="password"]').fill(ADMIN_CREDENTIALS.password);
   await page.locator('form button').click();
-  // await expect(page).toHaveURL(/.*welcome/);
-  await page.waitForLoadState();
+  // Assert the post-login redirect actually happens — without this the test
+  // "passes" even when login is completely broken (e.g. the API is unreachable).
+  await expect(page).toHaveURL(`${BASE_URL}/#/welcome`, { timeout: 30000 });
 });

--- a/src/e2e/newCourse.e2e.spec.ts
+++ b/src/e2e/newCourse.e2e.spec.ts
@@ -27,8 +27,10 @@ test.describe('New course', () => {
     await page.waitForSelector('text=Go to course page', { state: 'visible' });
     await page.locator('text=Go to course page').click();
 
-    const courseSavedAlert = await page.locator('.ant-message-notice');
-    await expect(courseSavedAlert).toContainText('Course saved successfully');
+    const courseSavedAlert = page.locator('.ant-message-notice', {
+      hasText: 'Course saved successfully',
+    });
+    await expect(courseSavedAlert).toBeVisible();
 
     await page.goto(`${BASE_URL}/#/courses/list`);
     await page.waitForSelector('.ant-table-tbody .ant-table-row-level-0', { state: 'visible' }); // w8 for initial list before querying

--- a/src/e2e/newUser.e2e.spec.ts
+++ b/src/e2e/newUser.e2e.spec.ts
@@ -16,7 +16,7 @@ test.describe('New user', () => {
     await page.click('[data-row-key="return_url"] button');
     await page.getByRole('textbox', { name: 'Please enter' }).fill('');
     await page.getByRole('textbox', { name: 'Please enter' }).fill('http://localhost');
-    await page.click('text=OK');
+    await page.locator('.ant-modal').getByRole('button', { name: 'OK', exact: true }).click();
     await page.waitForTimeout(2000);
     await page.waitForLoadState();
 


### PR DESCRIPTION
* chore: bump and pin @testing-library/jest-dom to 6.9.1
* [fix(e2e): proxy the API through nginx and use the seeded admin creds](https://github.com/EscolaLMS/Admin/pull/1154/changes/49fd3e4e3462c2869f8a29edb48c10c4f0d252d5)